### PR TITLE
Add Preview Port panel and enhance Edit View functionality

### DIFF
--- a/ui/camera_preview_panel.odin
+++ b/ui/camera_preview_panel.odin
@@ -1,0 +1,55 @@
+package ui
+
+import rl "vendor:raylib"
+
+// draw_preview_port_content renders a rasterized 3D preview from the render camera
+// (app.camera_params) and scene (app.edit_view.objects) into the panel content area.
+draw_preview_port_content :: proc(app: ^App, content: rl.Rectangle) {
+	new_w := i32(content.width)
+	new_h := i32(content.height)
+
+	if new_w != app.preview_port_w || new_h != app.preview_port_h {
+		if app.preview_port_w > 0 {
+			rl.UnloadRenderTexture(app.preview_port_tex)
+		}
+		if new_w > 0 && new_h > 0 {
+			app.preview_port_tex = rl.LoadRenderTexture(new_w, new_h)
+		}
+		app.preview_port_w = new_w
+		app.preview_port_h = new_h
+	}
+
+	if app.preview_port_w <= 0 || app.preview_port_h <= 0 { return }
+
+	cp := &app.camera_params
+	cam3d := rl.Camera3D{
+		position   = rl.Vector3{cp.lookfrom[0], cp.lookfrom[1], cp.lookfrom[2]},
+		target     = rl.Vector3{cp.lookat[0], cp.lookat[1], cp.lookat[2]},
+		up         = rl.Vector3{cp.vup[0], cp.vup[1], cp.vup[2]},
+		fovy       = cp.vfov,
+		projection = .PERSPECTIVE,
+	}
+
+	rl.BeginTextureMode(app.preview_port_tex)
+	rl.ClearBackground(rl.Color{20, 25, 35, 255})
+	rl.BeginMode3D(cam3d)
+	rl.DrawGrid(20, 1.0)
+
+	for s in app.edit_view.objects {
+		center := rl.Vector3{s.center[0], s.center[1], s.center[2]}
+		col := rl.Color{
+			u8(clamp(s.albedo[0], f32(0), f32(1)) * 255),
+			u8(clamp(s.albedo[1], f32(0), f32(1)) * 255),
+			u8(clamp(s.albedo[2], f32(0), f32(1)) * 255),
+			255,
+		}
+		rl.DrawSphere(center, s.radius, col)
+		rl.DrawSphereWires(center, s.radius, 8, 8, rl.Color{30, 30, 30, 180})
+	}
+
+	rl.EndMode3D()
+	rl.EndTextureMode()
+
+	src := rl.Rectangle{0, 0, f32(app.preview_port_w), -f32(app.preview_port_h)}
+	rl.DrawTexturePro(app.preview_port_tex.texture, src, content, rl.Vector2{0, 0}, 0.0, rl.WHITE)
+}

--- a/ui/layout.odin
+++ b/ui/layout.odin
@@ -147,13 +147,17 @@ layout_build_default :: proc(app: ^App, layout: ^DockLayout) {
     p_log    := layout_add_panel(layout, layout_find_panel_index(app, PANEL_ID_LOG))
     p_cam    := layout_add_panel(layout, layout_find_panel_index(app, PANEL_ID_CAMERA))
     p_props  := layout_add_panel(layout, layout_find_panel_index(app, PANEL_ID_OBJECT_PROPS))
+    p_preview := layout_add_panel(layout, layout_find_panel_index(app, PANEL_ID_PREVIEW_PORT))
 
-    center_leaf := layout_add_leaf(layout, []int{p_render, p_edit}, 0)
-    upper_right := layout_add_leaf(layout, []int{p_stats, p_sys}, 0)
-    lower_right := layout_add_leaf(layout, []int{p_log, p_cam, p_props}, 0)
+    center_leaf  := layout_add_leaf(layout, []int{p_render, p_edit}, 0)
+    upper_right  := layout_add_leaf(layout, []int{p_stats, p_sys}, 0)
+    lower_right  := layout_add_leaf(layout, []int{p_log, p_cam, p_props}, 0)
+    preview_leaf := layout_add_leaf(layout, []int{p_preview}, 0)
 
-    right_split := layout_add_split(layout, .DOCK_SPLIT_HORIZONTAL, upper_right, lower_right, 0.45)
-    root        := layout_add_split(layout, .DOCK_SPLIT_VERTICAL, center_leaf, right_split, 0.72)
+    // Right column: top = stats/sys, middle = log/camera/props, bottom = Preview Port
+    right_bottom := layout_add_split(layout, .DOCK_SPLIT_HORIZONTAL, lower_right, preview_leaf, 0.72)
+    right_split  := layout_add_split(layout, .DOCK_SPLIT_HORIZONTAL, upper_right, right_bottom, 0.45)
+    root         := layout_add_split(layout, .DOCK_SPLIT_VERTICAL, center_leaf, right_split, 0.72)
     layout.root = root
     layout.center_leaf = center_leaf
     layout.center_split_view = true


### PR DESCRIPTION
- Introduced a new `PANEL_ID_PREVIEW_PORT` for rendering a rasterized view from the render camera.
- Updated the `App` structure to include `preview_port_tex`, `preview_port_w`, and `preview_port_h` for managing the preview port state.
- Enhanced `run_app` to initialize the Preview Port panel and manage its layout within the UI.
- Modified `EditViewState` to support selection of both spheres and cameras, improving interaction in the Edit View.
- Updated Object Properties panel to handle camera parameters alongside sphere properties, allowing for more comprehensive editing options.