### PR TITLE
Add linear undo/redo history for scene edits (Ctrl+Z / Ctrl+Y)

### DIFF
--- a/editor/commands.odin
+++ b/editor/commands.odin
@@ -21,6 +21,9 @@ CMD_VIEW_PRESET_RENDER  :: "view.preset.render_focus"
 CMD_VIEW_PRESET_EDIT    :: "view.preset.edit_focus"
 CMD_VIEW_SAVE_PRESET    :: "view.preset.save"
 
+CMD_UNDO             :: "edit.undo"
+CMD_REDO             :: "edit.redo"
+
 CMD_RENDER_RESTART   :: "render.restart"
 
 MAX_COMMANDS :: 64

--- a/editor/edit_history.odin
+++ b/editor/edit_history.odin
@@ -1,0 +1,73 @@
+package editor
+
+import "RT_Weekend:core"
+
+EDIT_HISTORY_MAX :: 128
+
+ModifySphereAction :: struct {
+    idx:    int,
+    before: core.SceneSphere,
+    after:  core.SceneSphere,
+}
+
+AddSphereAction :: struct {
+    idx:    int,
+    sphere: core.SceneSphere,
+}
+
+DeleteSphereAction :: struct {
+    idx:    int,
+    sphere: core.SceneSphere,
+}
+
+ModifyCameraAction :: struct {
+    before: core.CameraParams,
+    after:  core.CameraParams,
+}
+
+EditAction :: union { ModifySphereAction, AddSphereAction, DeleteSphereAction, ModifyCameraAction }
+
+EditHistory :: struct {
+    actions: [dynamic]EditAction,
+    cursor:  int,
+}
+
+edit_history_free :: proc(h: ^EditHistory) {
+    delete(h.actions)
+}
+
+// edit_history_push truncates the redo branch, evicts the oldest entry when at capacity,
+// appends the new action, and advances the cursor.
+edit_history_push :: proc(h: ^EditHistory, action: EditAction) {
+    // Truncate redo branch
+    resize(&h.actions, h.cursor)
+    // Evict oldest entry when at capacity
+    if len(h.actions) >= EDIT_HISTORY_MAX {
+        ordered_remove(&h.actions, 0)
+    }
+    append(&h.actions, action)
+    h.cursor = len(h.actions)
+}
+
+// edit_history_undo decrements the cursor and returns the action to be reverted.
+edit_history_undo :: proc(h: ^EditHistory) -> (action: EditAction, ok: bool) {
+    if h.cursor <= 0 { return }
+    h.cursor -= 1
+    return h.actions[h.cursor], true
+}
+
+// edit_history_redo returns the action at the cursor and advances it.
+edit_history_redo :: proc(h: ^EditHistory) -> (action: EditAction, ok: bool) {
+    if h.cursor >= len(h.actions) { return }
+    action = h.actions[h.cursor]
+    h.cursor += 1
+    return action, true
+}
+
+edit_history_can_undo :: proc(h: ^EditHistory) -> bool {
+    return h.cursor > 0
+}
+
+edit_history_can_redo :: proc(h: ^EditHistory) -> bool {
+    return h.cursor < len(h.actions)
+}

--- a/editor/menu_bar.odin
+++ b/editor/menu_bar.odin
@@ -75,14 +75,20 @@ get_menus_dynamic :: proc(app: ^App) -> []MenuDyn {
         {label = "Exit",     cmd_id = CMD_FILE_EXIT,    shortcut = "Alt+F4"},
     }
 
+    edit_entries := []MenuEntryDyn{
+        {label = "Undo", cmd_id = CMD_UNDO, shortcut = "Ctrl+Z", disabled = !cmd_is_enabled(app, CMD_UNDO)},
+        {label = "Redo", cmd_id = CMD_REDO, shortcut = "Ctrl+Y", disabled = !cmd_is_enabled(app, CMD_REDO)},
+    }
+
     render_entries := []MenuEntryDyn{
         {label = "Restart", cmd_id = CMD_RENDER_RESTART, shortcut = "F5", disabled = !cmd_is_enabled(app, CMD_RENDER_RESTART)},
     }
 
-    menus := make([]MenuDyn, 3, context.temp_allocator)
+    menus := make([]MenuDyn, 4, context.temp_allocator)
     menus[0] = MenuDyn{title = "File",   entries = file_entries}
-    menus[1] = MenuDyn{title = "View",   entries = view_entries[:]}
-    menus[2] = MenuDyn{title = "Render", entries = render_entries}
+    menus[1] = MenuDyn{title = "Edit",   entries = edit_entries}
+    menus[2] = MenuDyn{title = "View",   entries = view_entries[:]}
+    menus[3] = MenuDyn{title = "Render", entries = render_entries}
     return menus
 }
 

--- a/editor/scene_manager.odin
+++ b/editor/scene_manager.odin
@@ -95,3 +95,11 @@ SetSceneSphere :: proc(sm: ^SceneManager, idx: int, s: core.SceneSphere) {
 	if idx < 0 || idx >= len(sm.objects) { return }
 	sm.objects[idx] = s
 }
+
+// InsertSphereAt inserts a sphere at the given index, shifting later elements right.
+InsertSphereAt :: proc(sm: ^SceneManager, idx: int, s: core.SceneSphere) {
+	if sm == nil { return }
+	if idx < 0 || idx > len(sm.objects) { return }
+	obj: EditorObject = s
+	inject_at(&sm.objects, idx, obj)
+}


### PR DESCRIPTION
## Summary

- Adds a bounded 128-entry undo/redo stack (`EditHistory`) covering all scene mutations in the editor
- New **Edit** menu in the menu bar (between File and View) with Undo/Redo entries showing correct enabled state
- Each committed action is written to the existing log ring

## Actions tracked

| Interaction | Commit point |
|---|---|
| Viewport sphere drag | On mouse release |
| Keyboard nudge (WASD/QE/+/-) | When all keys released |
| Add sphere button | Immediately after append |
| Delete sphere button | Before removal |
| Object Props property drag (sphere) | On mouse release |
| Object Props property drag (camera) | On mouse release |
| Material toggle (Lambertian/Metallic/Dielectric) | Immediately on click |

## Architecture

- `editor/edit_history.odin` — new file: `EditHistory`, `EditAction` union, push/undo/redo procs
- `EditAction` union: `ModifySphereAction`, `AddSphereAction`, `DeleteSphereAction`, `ModifyCameraAction`
- Capped at 128 entries; oldest evicted via `ordered_remove` — no heap growth beyond that
- All action fields are value types (no internal pointers) — single `delete(h.actions)` on shutdown
- `InsertSphereAt` added to `scene_manager.odin` (uses `inject_at`) for delete-undo restore
- Keyboard shortcuts: **Ctrl+Z** = Undo, **Ctrl+Y** / **Ctrl+Shift+Z** = Redo

## Test plan

- [ ] Drag a sphere in the viewport → Ctrl+Z restores position → Ctrl+Y moves it back
- [ ] Add sphere → Ctrl+Z removes it → Ctrl+Y re-adds it at the correct index
- [ ] Delete sphere → Ctrl+Z restores it at the correct index with correct material
- [ ] Drag a property in Object Props (position, color, fuzz) → Ctrl+Z reverts
- [ ] Toggle material type → Ctrl+Z reverts
- [ ] Edit menu shows Undo/Redo with correct greyed-out state
- [ ] Log panel shows action description for each committed change
- [ ] After 130+ edits, no crash and no unbounded memory growth

🤖 Generated with [Claude Code](https://claude.com/claude-code)