### PR TITLE
Clarify sphere count in logs (user spheres vs ground plane)

### DIFF
--- a/editor/app.odin
+++ b/editor/app.odin
@@ -111,7 +111,7 @@ app_restart_render :: proc(app: ^App, new_world: [dynamic]rt.Object) {
     rt.apply_scene_camera(app.r_camera, &app.c_camera_params)
     rt.init_camera(app.r_camera)
     app.r_session = rt.start_render_auto(app.r_camera, app.r_world, app.num_threads, app.prefer_gpu)
-    app_push_log(app, fmt.aprintf("Re-rendering (%d objects)...", len(app.r_world)))
+    app_push_log(app, fmt.aprintf("Re-rendering (%d user spheres + 1 ground plane)...", rt.count_user_spheres(app.r_world[:])))
 }
 
 // app_restart_render_with_scene builds a raytrace world from shared scene objects and starts a fresh render.
@@ -132,7 +132,7 @@ app_restart_render_with_scene :: proc(app: ^App, scene_objects: []core.SceneSphe
     rt.apply_scene_camera(app.r_camera, &app.c_camera_params)
     rt.init_camera(app.r_camera)
     app.r_session = rt.start_render_auto(app.r_camera, app.r_world, app.num_threads, app.prefer_gpu)
-    app_push_log(app, fmt.aprintf("Re-rendering (%d objects)...", len(app.r_world)))
+    app_push_log(app, fmt.aprintf("Re-rendering (%d user spheres + 1 ground plane)...", len(scene_objects)))
 }
 
 App :: struct {
@@ -499,6 +499,7 @@ run_app :: proc(
     }
 
     app_push_log(&app, fmt.aprintf("Scene: %dx%d, %d spp", r_camera.image_width, r_camera.image_height, r_camera.samples_per_pixel))
+    app_push_log(&app, fmt.aprintf("Spheres: %d user + 1 implicit ground plane", rt.count_user_spheres(app.r_world[:])))
     app_push_log(&app, fmt.aprintf("Threads: %d", num_threads))
     if use_gpu {
         app_push_log(&app, strings.clone("Starting render (GPU mode requested)..."))

--- a/raytrace/gpu_backend.odin
+++ b/raytrace/gpu_backend.odin
@@ -216,8 +216,13 @@ gpu_backend_init :: proc(
     gl.BufferData(gl.SHADER_STORAGE_BUFFER, output_total, raw_data(zeroes), gl.DYNAMIC_COPY)
     gl.BindBuffer(gl.SHADER_STORAGE_BUFFER, 0)
 
-    fmt.printf("[GPU] Buffers ready — %d spheres, %d BVH nodes, %dx%d px\n",
-        len(spheres), len(lin_bvh), cam.image_width, cam.image_height)
+    // Report user spheres separately from the implicit ground plane (centre.y < -100).
+    user_sphere_count := 0
+    for s in spheres {
+        if s.center[1] > -100 { user_sphere_count += 1 }
+    }
+    fmt.printf("[GPU] Buffers ready — %d spheres (%d user + 1 ground plane), %d BVH nodes, %dx%d px\n",
+        len(spheres), user_sphere_count, len(lin_bvh), cam.image_width, cam.image_height)
     return b, true
 }
 

--- a/raytrace/scene_build.odin
+++ b/raytrace/scene_build.odin
@@ -29,6 +29,19 @@ convert_world_to_edit_spheres :: proc(world: [dynamic]Object) -> [dynamic]core.S
 	return result
 }
 
+// count_user_spheres returns the number of user-placed spheres in world,
+// excluding the implicit ground plane (centre.y < -100).
+count_user_spheres :: proc(world: []Object) -> int {
+	count := 0
+	for obj in world {
+		s, ok := obj.(Sphere)
+		if !ok { continue }
+		if s.center[1] < -100 { continue }
+		count += 1
+	}
+	return count
+}
+
 // build_world_from_scene converts shared scene spheres to raytrace Objects.
 // Prepends a grey ground plane. Caller owns and must delete the returned dynamic array.
 build_world_from_scene :: proc(scene_objects: []core.SceneSphere) -> [dynamic]Object {


### PR DESCRIPTION
## Summary
- Log messages showed N+1 spheres because `build_world_from_scene` always prepends an implicit ground plane sphere, which was counted silently alongside user-placed spheres
- Added `count_user_spheres` helper in `raytrace/scene_build.odin` (mirrors the `center.y < -100` filter already used in `convert_world_to_edit_spheres`)
- Updated all three log sites to show the breakdown explicitly: `N user + 1 ground plane`

## Affected logs
- **Startup:** `Spheres: 3 user + 1 implicit ground plane`
- **Re-render:** `Re-rendering (3 user spheres + 1 ground plane)...`
- **GPU backend:** `[GPU] Buffers ready — 4 spheres (3 user + 1 ground plane), 7 BVH nodes, 1600x900 px`

## Test plan
- [ ] Launch with 3 user spheres — startup log shows `Spheres: 3 user + 1 implicit ground plane`
- [ ] Add/remove spheres in editor and re-render — log shows correct user count
- [ ] Run with `-gpu` flag — GPU backend log shows breakdown instead of total-only count

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)