### PR TITLE
Add motion blur and Next Week: Bouncing Balls scene

### DIFF
--- a/core/types.odin
+++ b/core/types.odin
@@ -11,12 +11,14 @@ MaterialKind :: enum {
 // SceneSphere is the canonical in-memory representation of a sphere for the editor and the renderer.
 // The edit view stores these; raytrace.build_world_from_scene converts them to raytrace.Object.
 SceneSphere :: struct {
-	center:       [3]f32,
-	radius:       f32,
+	center:        [3]f32,
+	center1:       [3]f32, // end position for motion blur (t=1); only used when is_moving
+	radius:        f32,
 	material_kind: MaterialKind,
-	albedo:       [3]f32,
-	fuzz:         f32, // used for Metallic (default 0.1)
-	ref_idx:      f32, // used for Dielectric (default 1.5)
+	albedo:        [3]f32,
+	fuzz:          f32, // used for Metallic (default 0.1)
+	ref_idx:       f32, // used for Dielectric (default 1.5)
+	is_moving:     bool,
 }
 
 // CameraParams is the shared camera definition used by the edit view (and camera panel) and the path tracer.

--- a/editor/example_scenes.odin
+++ b/editor/example_scenes.odin
@@ -12,7 +12,8 @@ ExampleScene :: struct {
 
 // EXAMPLE_SCENES is the static registry of built-in example scenes.
 EXAMPLE_SCENES := []ExampleScene{
-    {label = "Weekend Final Scene", build = build_weekend_final_scene},
+    {label = "Weekend Final Scene",       build = build_weekend_final_scene},
+    {label = "Next Week: Bouncing Balls", build = build_next_week_bouncing_scene},
 }
 
 WEEKEND_CAMERA :: core.CameraParams{
@@ -84,6 +85,86 @@ build_weekend_final_scene :: proc() -> (spheres: []core.SceneSphere, camera: cor
     }
 
     // Three large spheres
+    append(&result, core.SceneSphere{
+        center        = {0, 1, 0},
+        radius        = 1.0,
+        material_kind = .Dielectric,
+        ref_idx       = 1.5,
+    })
+    append(&result, core.SceneSphere{
+        center        = {-4, 1, 0},
+        radius        = 1.0,
+        material_kind = .Lambertian,
+        albedo        = {0.4, 0.2, 0.1},
+    })
+    append(&result, core.SceneSphere{
+        center        = {4, 1, 0},
+        radius        = 1.0,
+        material_kind = .Metallic,
+        albedo        = {0.7, 0.6, 0.5},
+        fuzz          = 0.0,
+    })
+
+    return result[:], WEEKEND_CAMERA
+}
+
+// build_next_week_bouncing_scene returns the bouncing balls scene from "Ray Tracing: The Next Week" Chapter 2.
+// Lambertian small spheres are moving (motion blur); metallic and dielectric are static.
+// Uses the same fixed seed (42) and grid as build_weekend_final_scene. Caller must delete the returned slice.
+build_next_week_bouncing_scene :: proc() -> (spheres: []core.SceneSphere, camera: core.CameraParams) {
+    rng := util.create_thread_rng(42)
+
+    result := make([dynamic]core.SceneSphere)
+
+    for a in -11..<11 {
+        for b in -11..<11 {
+            choose_mat := util.random_float(&rng)
+            cx := f32(a) + 0.9 * util.random_float(&rng)
+            cz := f32(b) + 0.9 * util.random_float(&rng)
+
+            // Skip spheres too close to the big center sphere position
+            dx2 := cx - 4
+            dy2 := f32(0.2) - 0.2
+            dz2 := cz - 0
+            dist2 := math.sqrt(dx2*dx2 + dy2*dy2 + dz2*dz2)
+            if dist2 <= 0.9 { continue }
+
+            sphere: core.SceneSphere
+            sphere.center = {cx, 0.2, cz}
+            sphere.radius = 0.2
+
+            if choose_mat < 0.8 {
+                // Lambertian — moving sphere
+                r1 := util.random_float(&rng)
+                r2 := util.random_float(&rng)
+                g1 := util.random_float(&rng)
+                g2 := util.random_float(&rng)
+                b1 := util.random_float(&rng)
+                b2 := util.random_float(&rng)
+                sphere.material_kind = .Lambertian
+                sphere.albedo = {r1 * r2, g1 * g2, b1 * b2}
+                sphere.is_moving = true
+                sphere.center1 = sphere.center + [3]f32{0, util.random_float_range(&rng, 0, 0.5), 0}
+            } else if choose_mat < 0.95 {
+                // Metallic — static
+                sphere.material_kind = .Metallic
+                sphere.albedo = {
+                    util.random_float_range(&rng, 0.5, 1),
+                    util.random_float_range(&rng, 0.5, 1),
+                    util.random_float_range(&rng, 0.5, 1),
+                }
+                sphere.fuzz = util.random_float_range(&rng, 0, 0.5)
+            } else {
+                // Dielectric — static
+                sphere.material_kind = .Dielectric
+                sphere.ref_idx = 1.5
+            }
+
+            append(&result, sphere)
+        }
+    }
+
+    // Three large spheres (non-moving)
     append(&result, core.SceneSphere{
         center        = {0, 1, 0},
         radius        = 1.0,

--- a/raytrace/camera.odin
+++ b/raytrace/camera.odin
@@ -179,7 +179,7 @@ get_ray :: proc(r_camera: ^Camera, u : f32, v : f32, rng: ^util.ThreadRNG) -> ra
     ray_origin := (r_camera.defocus_angle <= 0)? r_camera.center : defocus_disk_sample(r_camera, rng)
     ray_direction := pixel_sample - ray_origin
 
-    return ray{ray_origin, ray_direction}
+    return ray{orig = ray_origin, dir = ray_direction, time = util.random_float(rng)}
 }
 
 // pixel_to_ray returns a deterministic ray through the center of pixel (px, py).
@@ -188,7 +188,7 @@ pixel_to_ray :: proc(r_camera: ^Camera, px, py: f32) -> ray {
     pixel_world := r_camera.pixel00_loc +
                    px * r_camera.pixel_delta_u +
                    py * r_camera.pixel_delta_v
-    return ray{r_camera.center, pixel_world - r_camera.center}
+    return ray{orig = r_camera.center, dir = pixel_world - r_camera.center}
 }
 
 defocus_disk_sample :: proc(c : ^Camera, rng: ^util.ThreadRNG) -> [3]f32 {

--- a/raytrace/hittable.odin
+++ b/raytrace/hittable.odin
@@ -13,9 +13,16 @@ hit_record :: struct {
 
 
 Sphere :: struct {
-    center : [3]f32,
-    radius : f32,
-    material : material,
+    center:    [3]f32,
+    center1:   [3]f32, // end position (t=1); only used when is_moving
+    radius:    f32,
+    material:  material,
+    is_moving: bool,
+}
+
+sphere_center_at :: proc(s: Sphere, time: f32) -> [3]f32 {
+    if !s.is_moving { return s.center }
+    return s.center + time * (s.center1 - s.center)
 }
 
 Cube :: struct {
@@ -36,11 +43,19 @@ AABB :: struct {
 }
 
 sphere_bounding_box :: proc(s: Sphere) -> AABB {
-    return AABB{
-        x = Interval{s.center[0] - s.radius, s.center[0] + s.radius},
-        y = Interval{s.center[1] - s.radius, s.center[1] + s.radius},
-        z = Interval{s.center[2] - s.radius, s.center[2] + s.radius},
+    r := s.radius
+    box0 := AABB{
+        x = Interval{s.center[0] - r, s.center[0] + r},
+        y = Interval{s.center[1] - r, s.center[1] + r},
+        z = Interval{s.center[2] - r, s.center[2] + r},
     }
+    if !s.is_moving { return box0 }
+    box1 := AABB{
+        x = Interval{s.center1[0] - r, s.center1[0] + r},
+        y = Interval{s.center1[1] - r, s.center1[1] + r},
+        z = Interval{s.center1[2] - r, s.center1[2] + r},
+    }
+    return aabb_union(box0, box1)
 }
 
 object_bounding_box :: proc(obj: Object) -> AABB {
@@ -48,7 +63,7 @@ object_bounding_box :: proc(obj: Object) -> AABB {
     case Sphere:
         return sphere_bounding_box(o)
     case Cube:
-        return sphere_bounding_box(Sphere{o.center, o.radius, material{}})
+        return sphere_bounding_box(Sphere{center = o.center, radius = o.radius})
     }
     return AABB{
         x = Interval{0, 0},
@@ -133,6 +148,7 @@ BVHNode :: struct {
 object_center :: proc(obj: Object, axis: int) -> f32 {
     switch o in obj {
     case Sphere:
+        if o.is_moving { return (o.center[axis] + o.center1[axis]) * 0.5 }
         return o.center[axis]
     case Cube:
         return o.center[axis]

--- a/raytrace/material.odin
+++ b/raytrace/material.odin
@@ -31,13 +31,13 @@ scatter :: proc (mat : material, r_in : ray, rec : hit_record, attenuation : ^[3
         if vector_length_squared(scatter_dir) < 1e-16 {
             scatter_dir = rec.normal
         }
-        scattered^ = ray{rec.p, scatter_dir}
+        scattered^ = ray{orig = rec.p, dir = scatter_dir, time = r_in.time}
         attenuation^ = m.albedo
         return true
     case metallic:
         reflected := vector_reflect(r_in.dir, rec.normal)
         reflected = unit_vector(reflected) + m.fuzz * vector_random_unit(rng)
-        scattered^ = ray{rec.p, reflected}
+        scattered^ = ray{orig = rec.p, dir = reflected, time = r_in.time}
         attenuation^ = m.albedo
         return dot(scattered.dir, rec.normal) > 0
     case dielectric:
@@ -60,7 +60,7 @@ scatter :: proc (mat : material, r_in : ray, rec : hit_record, attenuation : ^[3
             direction = vector_refract(unit_direction, rec.normal, ri)
         }
 
-        scattered^ = ray{rec.p, direction}
+        scattered^ = ray{orig = rec.p, dir = direction, time = r_in.time}
         return true
     }
     return false

--- a/raytrace/raytrace.odin
+++ b/raytrace/raytrace.odin
@@ -98,7 +98,7 @@ setup_scene :: proc(image_width, image_height, samples_per_pixel, number_of_sphe
     scene_rng := util.create_thread_rng(54321)
 
     ground_material := material(lambertian{[3]f32{0.5, 0.5, 0.5}})
-    append(&world, Sphere{[3]f32{0, -1000, 0}, 1000, ground_material})
+    append(&world, Sphere{center = {0, -1000, 0}, radius = 1000, material = ground_material})
 
     num_spheres := 0
     for a in -11..<11 {
@@ -110,15 +110,15 @@ setup_scene :: proc(image_width, image_height, samples_per_pixel, number_of_sphe
                 if choose_mat < 0.8 {
                     albedo   := vector_random(&scene_rng) * vector_random(&scene_rng)
                     mat      := material(lambertian{albedo})
-                    append(&world, Sphere{center, 0.2, mat})
+                    append(&world, Sphere{center = center, radius = 0.2, material = mat})
                 } else if choose_mat < 0.95 {
                     albedo   := vector_random_range(&scene_rng, 0.5, 1)
                     fuzz     := util.random_float_range(&scene_rng, 0, 0.5)
                     mat      := material(metallic{albedo, fuzz})
-                    append(&world, Sphere{center, 0.2, mat})
+                    append(&world, Sphere{center = center, radius = 0.2, material = mat})
                 } else {
                     mat := material(dielectric{1.5})
-                    append(&world, Sphere{center, 0.2, mat})
+                    append(&world, Sphere{center = center, radius = 0.2, material = mat})
                 }
                 num_spheres += 1
             }
@@ -129,13 +129,13 @@ setup_scene :: proc(image_width, image_height, samples_per_pixel, number_of_sphe
     }
 
     material1 := material(dielectric{1.5})
-    append(&world, Sphere{[3]f32{0, 1, 0}, 1.0, material1})
+    append(&world, Sphere{center = {0, 1, 0}, radius = 1.0, material = material1})
 
     material2 := material(lambertian{[3]f32{0.4, 0.2, 0.1}})
-    append(&world, Sphere{[3]f32{-4, 1, 0}, 1.0, material2})
+    append(&world, Sphere{center = {-4, 1, 0}, radius = 1.0, material = material2})
 
     material3 := material(metallic{[3]f32{0.7, 0.6, 0.5}, 0.0})
-    append(&world, Sphere{[3]f32{4, 1, 0}, 1.0, material3})
+    append(&world, Sphere{center = {4, 1, 0}, radius = 1.0, material = material3})
 
     cam := make_camera(image_width, image_height, samples_per_pixel)
     init_camera(cam)

--- a/raytrace/scene_build.odin
+++ b/raytrace/scene_build.odin
@@ -11,7 +11,7 @@ convert_world_to_edit_spheres :: proc(world: [dynamic]Object) -> [dynamic]core.S
 		s, ok := obj.(Sphere)
 		if !ok { continue }
 		if s.center[1] < -100 { continue } // skip ground plane
-		ss := core.SceneSphere{center = s.center, radius = s.radius}
+		ss := core.SceneSphere{center = s.center, center1 = s.center1, radius = s.radius, is_moving = s.is_moving}
 		switch m in s.material {
 		case lambertian:
 			ss.material_kind = .Lambertian
@@ -58,9 +58,11 @@ build_world_from_scene :: proc(scene_objects: []core.SceneSphere) -> [dynamic]Ob
 			mat = material(lambertian{albedo = s.albedo})
 		}
 		append(&world, Object(Sphere{
-			center   = s.center,
-			radius   = s.radius,
-			material = mat,
+			center    = s.center,
+			center1   = s.center1,
+			radius    = s.radius,
+			material  = mat,
+			is_moving = s.is_moving,
 		}))
 	}
 

--- a/raytrace/vector3.odin
+++ b/raytrace/vector3.odin
@@ -73,7 +73,8 @@ vector_random_in_unit_disk :: proc(rng: ^util.ThreadRNG) -> [3]f32 {
 
 
 hit_sphere :: proc (sphere : Sphere, r : ray,  ray_t : Interval, rec : ^hit_record) -> bool {
-    oc := sphere.center - r.orig
+    center := sphere_center_at(sphere, r.time)
+    oc := center - r.orig
     a := vector_length_squared(r.dir)
     h := dot(r.dir, oc)
     c := vector_length_squared(oc) - sphere.radius*sphere.radius
@@ -95,7 +96,7 @@ hit_sphere :: proc (sphere : Sphere, r : ray,  ray_t : Interval, rec : ^hit_reco
 
     rec.t = root
     rec.p = ray_at(r, rec.t)
-    outward_normal := (rec.p - sphere.center) / sphere.radius
+    outward_normal := (rec.p - center) / sphere.radius
 
     set_face_normal(rec, r, outward_normal)
 
@@ -106,6 +107,7 @@ hit_sphere :: proc (sphere : Sphere, r : ray,  ray_t : Interval, rec : ^hit_reco
 ray :: struct {
     orig : [3]f32,
     dir : [3]f32,
+    time : f32,
 }
 
 ray_at :: proc(r : ray, t : f32) -> [3]f32 {


### PR DESCRIPTION
## Summary
- Adds `time: f32` to `ray`; `get_ray` samples a random time in [0,1) per sample so moving spheres produce motion blur
- Adds `center1`/`is_moving` fields to `Sphere` and `SceneSphere`; `sphere_center_at` interpolates the position at ray time; `sphere_bounding_box` covers the full motion arc for correct BVH culling
- Adds `build_next_week_bouncing_scene` (Chapter 2 of *The Next Week*): Lambertian small spheres move upward, metallic/dielectric and large spheres are static; registered as a second entry in the Examples menu

## Test plan
- [x] `make debug` compiles cleanly
- [x] Examples menu shows both "Weekend Final Scene" and "Next Week: Bouncing Balls"
- [x] Weekend Final Scene renders identically to before (no blur, same seed 42)
- [ ] Next Week: Bouncing Balls shows motion blur streaks upward on small Lambertian spheres
- [x] Reloading each scene gives identical results (deterministic seed)
- [x] GPU path (if available) renders without crash (static t=0 positions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)