### PR TITLE
Add AABB and BVH hierarchy visualization options in EditViewState

### DIFF
--- a/editor/app.odin
+++ b/editor/app.odin
@@ -431,6 +431,12 @@ run_app :: proc(
     defer { if app.preview_port_w > 0 { rl.UnloadRenderTexture(app.preview_port_tex) } }
     defer delete(app.e_edit_view.export_scratch)
     defer free_scene_manager(app.e_edit_view.scene_mgr)
+    defer {
+        if app.e_edit_view.viz_bvh_root != nil {
+            rt.free_bvh(app.e_edit_view.viz_bvh_root)
+            app.e_edit_view.viz_bvh_root = nil
+        }
+    }
     defer { rt.free_session(app.r_session) }
     defer delete(app.r_world)
     defer {

--- a/editor/panel_edit_view.odin
+++ b/editor/panel_edit_view.odin
@@ -665,14 +665,12 @@ draw_edit_view_content :: proc(app: ^App, content: rl.Rectangle) {
 
 	// AABB / BVH visualization toggles
 	btn_aabb, btn_sel, btn_bvh, btn_d_plus, btn_d_minus := edit_view_aabb_toolbar_rects(content)
-	aabb_hover := rl.CheckCollisionPointRec(mouse, btn_aabb)
-	sel_hover  := rl.CheckCollisionPointRec(mouse, btn_sel)
-	bvh_hover  := rl.CheckCollisionPointRec(mouse, btn_bvh)
-	btn_aabb    := rl.Rectangle{content.x + 278, content.y + 5, 44, 22}
-	btn_sel     := rl.Rectangle{content.x + 324, content.y + 5, 28, 22}
-	btn_bvh     := rl.Rectangle{content.x + 354, content.y + 5, 34, 22}
-	btn_d_plus  := rl.Rectangle{content.x + 390, content.y + 5, 22, 22}
-	btn_d_minus := rl.Rectangle{content.x + 414, content.y + 5, 22, 22}
+
+	// btn_aabb    := rl.Rectangle{content.x + 278, content.y + 5, 44, 22}
+	// btn_sel     := rl.Rectangle{content.x + 324, content.y + 5, 28, 22}
+	// btn_bvh     := rl.Rectangle{content.x + 354, content.y + 5, 34, 22}
+	// btn_d_plus  := rl.Rectangle{content.x + 390, content.y + 5, 22, 22}
+	// btn_d_minus := rl.Rectangle{content.x + 414, content.y + 5, 22, 22}
 	aabb_hover   := rl.CheckCollisionPointRec(mouse, btn_aabb)
 	sel_hover    := rl.CheckCollisionPointRec(mouse, btn_sel)
 	bvh_hover    := rl.CheckCollisionPointRec(mouse, btn_bvh)
@@ -1078,6 +1076,10 @@ update_edit_view_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vector
 		}
 		if rl.CheckCollisionPointRec(mouse, btn_bvh) {
 			ev.show_bvh_hierarchy = !ev.show_bvh_hierarchy
+			if !ev.show_bvh_hierarchy && ev.viz_bvh_root != nil {
+				rt.free_bvh(ev.viz_bvh_root)
+				ev.viz_bvh_root = nil
+			}
 			if g_app != nil { g_app.input_consumed = true }
 			return
 		}


### PR DESCRIPTION
- Introduced new fields in EditViewState for toggling AABB visualization, selecting only highlighted AABBs, displaying BVH hierarchy, and setting a maximum depth for BVH rendering.
- Updated initialization to set default values for the new visualization options.
- Implemented drawing logic for AABBs and BVH hierarchy in the 3D viewport, allowing users to visualize scene structures more effectively.
- Added UI elements for toggling AABB and BVH visualizations, enhancing user interaction and control over scene rendering.