### PR TITLE
Enhance texture mapping for spheres and cubes in ray tracing engine

### DIFF
--- a/assets/shaders/raytrace.comp
+++ b/assets/shaders/raytrace.comp
@@ -10,6 +10,9 @@
 //   • Iterative BVH traversal (the same flat LinearBVHNode array
 //     built by flatten_bvh in hittable.odin)
 //
+// Texture mapping: HitRecord stores (u,v) in [0,1]. Spheres use sphere_get_uv
+// (theta/phi, RTNW Ch.4). Cubes are CPU-only; GPU path has spheres only.
+//
 // Workgroup: 8×8 threads — 64 threads per tile, matching typical
 // GPU warp/wavefront sizes for good occupancy.
 //
@@ -201,6 +204,7 @@ struct HitRecord {
     vec3  normal;     // outward normal at hit point
     float t;          // ray parameter at hit
     bool  front_face; // true if ray hit the outside of the surface
+    float u, v;       // texture coordinates [0,1] (sphere: theta/phi; cube: CPU-only)
     int   mat_type;
     vec3  albedo;
     float fuzz_or_ior;
@@ -215,6 +219,16 @@ struct HitRecord {
 void set_face_normal(inout HitRecord rec, Ray r, vec3 outward_normal) {
     rec.front_face = dot(r.dir, outward_normal) < 0.0;
     rec.normal = rec.front_face ? outward_normal : -outward_normal;
+}
+
+// Sphere UV mapping (RTNW Ch.4): unit surface point p -> (u,v) in [0,1].
+// theta = acos(-p.y), phi = atan2(-p.z, p.x) + PI; u = phi/(2*PI), v = theta/PI.
+vec2 sphere_get_uv(vec3 p) {
+    float theta = acos(-p.y);
+    float phi   = atan(-p.z, p.x) + 3.14159265359;
+    float u     = phi / (2.0 * 3.14159265359);
+    float v     = theta / 3.14159265359;
+    return vec2(u, v);
 }
 
 // hit_sphere tests a ray against a sphere using the quadratic formula.
@@ -241,6 +255,9 @@ bool hit_sphere(Sphere s, Ray r, float t_min, float t_max, out HitRecord rec) {
     rec.p = ray_at(r, rec.t);
     vec3 outward_normal = (rec.p - sphere_center) / s.radius;
     set_face_normal(rec, r, outward_normal);
+    vec2 uv = sphere_get_uv(outward_normal);
+    rec.u = uv.x;
+    rec.v = uv.y;
     rec.mat_type    = s.mat_type;
     rec.albedo      = s.albedo;
     rec.fuzz_or_ior = s.fuzz_or_ior;

--- a/raytrace/hittable.odin
+++ b/raytrace/hittable.odin
@@ -33,10 +33,47 @@ sphere_center_at :: proc(s: Sphere, time: f32) -> [3]f32 {
     return s.center + time * (s.center1 - s.center)
 }
 
+// sphere_get_uv returns (u, v) texture coordinates for a unit-sphere surface point p.
+// p is the normalized hit point relative to sphere center (outward_normal for a sphere).
+// Follows Ray Tracing: The Next Week Ch.4: theta = acos(-p.y), phi = atan2(-p.z, p.x) + π.
+sphere_get_uv :: proc(p: [3]f32) -> (u, v: f32) {
+    theta := math.acos(-p.y)
+    phi   := math.atan2(-p.z, p.x) + math.PI
+    u = phi / (2.0 * math.PI)
+    v = theta / math.PI
+    return
+}
+
 Cube :: struct {
     center : [3]f32,
     radius : f32,
     material : material,
+}
+
+// cube_get_uv returns (u, v) in [0,1] using face-projected UV: dominant axis of the
+// outward normal, then the two remaining axes normalized to the cube face extent.
+// No per-face unwrap; suitable as a simple fallback for image textures.
+cube_get_uv :: proc(p: [3]f32, outward_normal: [3]f32, center: [3]f32, radius: f32) -> (u, v: f32) {
+    // Dominant axis of the outward normal (which face was hit).
+    ax := 0
+    if math.abs(outward_normal[1]) > math.abs(outward_normal[ax]) { ax = 1 }
+    if math.abs(outward_normal[2]) > math.abs(outward_normal[ax]) { ax = 2 }
+    // The two other axes for (u, v).
+    axis_u: int = 1 if ax == 0 else 0
+    axis_v: int = 2
+    if ax == 1 {
+        axis_u = 0
+        axis_v = 2
+    } else if ax == 2 {
+        axis_u = 0
+        axis_v = 1
+    }
+    half := 2.0 * radius
+    u = (p[axis_u] - center[axis_u] + radius) / half
+    v = (p[axis_v] - center[axis_v] + radius) / half
+    u = math.clamp(u, 0.0, 1.0)
+    v = math.clamp(v, 0.0, 1.0)
+    return
 }
 
 Object :: union {
@@ -689,7 +726,11 @@ hit :: proc(r : ray, ray_t : Interval, rec : ^hit_record, object : Object, close
             return true
         }
     case Cube:
-        return false
+        if hit_cube(s, r, Interval{ray_t.min, closest_so_far^}, &temp_rec) {
+            rec^ = temp_rec
+            closest_so_far^ = temp_rec.t
+            return true
+        }
     }
     return false
 }

--- a/raytrace/vector3.odin
+++ b/raytrace/vector3.odin
@@ -101,6 +101,73 @@ hit_sphere :: proc (sphere : Sphere, r : ray,  ray_t : Interval, rec : ^hit_reco
     outward_normal := (rec.p - current_center) / sphere.radius
 
     set_face_normal(rec, r, outward_normal)
+    rec.u, rec.v = sphere_get_uv(outward_normal)
+
+    return true
+}
+
+// hit_cube tests a ray against an axis-aligned cube (center ± radius). Uses slab method,
+// records the entry face and sets rec.u, rec.v via cube_get_uv (face-projected).
+hit_cube :: proc(cube: Cube, r: ray, ray_t: Interval, rec: ^hit_record) -> bool {
+    box_min := [3]f32{
+        cube.center[0] - cube.radius,
+        cube.center[1] - cube.radius,
+        cube.center[2] - cube.radius,
+    }
+    box_max := [3]f32{
+        cube.center[0] + cube.radius,
+        cube.center[1] + cube.radius,
+        cube.center[2] + cube.radius,
+    }
+    inv_dir := [3]f32{
+        1.0 / r.dir[0],
+        1.0 / r.dir[1],
+        1.0 / r.dir[2],
+    }
+    t_min := ray_t.min
+    t_max := ray_t.max
+    norm_axis := 0
+    norm_sign: f32 = 1.0
+
+    for i in 0 ..< 3 {
+        t_lo := (box_min[i] - r.origin[i]) * inv_dir[i]
+        t_hi := (box_max[i] - r.origin[i]) * inv_dir[i]
+        if inv_dir[i] < 0 {
+            t_lo, t_hi = t_hi, t_lo
+        }
+        if t_lo > t_min {
+            t_min = t_lo
+            norm_axis = i
+            norm_sign = -1.0 if inv_dir[i] >= 0 else 1.0
+        }
+        if t_hi < t_max {
+            t_max = t_hi
+        }
+        if t_min > t_max {
+            return false
+        }
+    }
+
+    // Only accept entry hit (t_min) in the ray interval.
+    if t_min > ray_t.max || t_max < ray_t.min {
+        return false
+    }
+    if t_min < ray_t.min {
+        return false
+    }
+    t := t_min
+    if !interval_surrounds(ray_t, t) {
+        return false
+    }
+
+    rec.material = cube.material
+    rec.t = t
+    rec.p = ray_at(r, rec.t)
+    outward_normal := [3]f32{0, 0, 0}
+    outward_normal[norm_axis] = norm_sign
+
+    set_face_normal(rec, r, outward_normal)
+    rec.u, rec.v = cube_get_uv(rec.p, outward_normal, cube.center, cube.radius)
 
     return true
 }


### PR DESCRIPTION
- Added UV mapping support for spheres using spherical coordinates, with texture coordinates stored in the HitRecord structure.
- Implemented cube UV mapping using face-projected coordinates, providing a fallback for image textures.
- Updated hit detection functions for spheres and cubes to calculate and store texture coordinates upon intersection.
- Enhanced documentation to clarify the new texture mapping functionalities and their integration into the ray tracing workflow.