### PR TITLE
Enhance material handling with new TextureKind and SceneSphere updates

### DIFF
--- a/core/types.odin
+++ b/core/types.odin
@@ -37,6 +37,13 @@ Texture :: union {
 	MarbleTexture,
 }
 
+// TextureKind selects the Lambertian texture type for persistence and scene build.
+TextureKind :: enum {
+	Constant,
+	Checker,
+	Image,
+}
+
 // MaterialKind is the shared material type used by the edit view (Raylib) and the path tracer.
 // Both sides use this enum so no package needs to depend on the other's material representation.
 MaterialKind :: enum {
@@ -47,15 +54,21 @@ MaterialKind :: enum {
 
 // SceneSphere is the canonical in-memory representation of a sphere for the editor and the renderer.
 // The edit view stores these; raytrace.build_world_from_scene converts them to raytrace.Object.
+// For Lambertian: texture_kind and optional checker_* / image_path define the texture (albedo = even/constant color).
 SceneSphere :: struct {
-	center:        [3]f32,
-	center1:       [3]f32, // end position for motion blur (t=1); only used when is_moving
-	radius:        f32,
-	material_kind: MaterialKind,
-	albedo:        Texture,
-	fuzz:          f32, // used for Metallic (default 0.1)
-	ref_idx:       f32, // used for Dielectric (default 1.5)
-	is_moving:     bool,
+	center:            [3]f32,
+	center1:           [3]f32, // end position for motion blur (t=1); only used when is_moving
+	radius:            f32,
+	material_kind:     MaterialKind,
+	albedo:            Texture,
+	// Lambertian texture (used when material_kind == .Lambertian)
+	texture_kind:      TextureKind,  // default .Constant
+	checker_scale:     f32,          // for .Checker (default 1)
+	checker_color_odd: [3]f32,       // for .Checker; even = albedo
+	image_path:        string,       // for .Image; path (absolute or relative to scene file)
+	fuzz:              f32,          // used for Metallic (default 0.1)
+	ref_idx:           f32,          // used for Dielectric (default 1.5)
+	is_moving:         bool,
 }
 
 // CameraParams is the shared camera definition used by the edit view (and camera panel) and the path tracer.

--- a/editor/app.odin
+++ b/editor/app.odin
@@ -118,7 +118,7 @@ app_build_world_from_scene :: proc(app: ^App, scene_objects: []core.SceneSphere)
     return rt.build_world_from_scene(
         scene_objects,
         app_active_ground_texture(app),
-        app.image_texture_cache,
+        &app.image_texture_cache,
         app.include_ground_plane,
     )
 }

--- a/editor/panel_file_modal.odin
+++ b/editor/panel_file_modal.odin
@@ -99,6 +99,16 @@ file_modal_update :: proc(app: ^App) {
     }
 }
 
+// world_has_ground_plane returns true if the world contains a sphere used as ground (center.y < -100).
+world_has_ground_plane :: proc(world: []rt.Object) -> bool {
+	for obj in world {
+		if s, ok := obj.(rt.Sphere); ok && s.center[1] < -100 {
+			return true
+		}
+	}
+	return false
+}
+
 // file_import_from_path loads a scene from path and restarts the render. Takes ownership of path (caller must not delete).
 // Used by native open dialog and by file_modal_confirm when FILE_MODAL_FALLBACK is used for Import.
 file_import_from_path :: proc(app: ^App, path: string) {
@@ -118,7 +128,8 @@ file_import_from_path :: proc(app: ^App, path: string) {
 
     edit_history_free(&app.edit_history)
     app.edit_history = EditHistory{}
-    app.include_ground_plane = true
+    // Only include ground plane when the loaded scene had one (sphere with center.y < -100).
+    app.include_ground_plane = world_has_ground_plane(world[:])
     app_set_ground_texture(app, nil)
 
     delete(app.current_scene_path)

--- a/editor/panel_obj_props.odin
+++ b/editor/panel_obj_props.odin
@@ -824,6 +824,8 @@ update_object_props_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vec
 				if _, ok3 := sphere.albedo.(core.ConstantTexture); !ok3 {
 					before := sphere
 					sphere.albedo = core.ConstantTexture{color = {0.5, 0.5, 0.5}}
+					sphere.texture_kind = .Constant
+					sphere.image_path = ""
 					SetSceneSphere(ev.scene_mgr, ev.selected_idx, sphere)
 					edit_history_push(&app.edit_history, ModifySphereAction{idx = ev.selected_idx, before = before, after = sphere})
 					mark_scene_dirty(app)
@@ -836,6 +838,8 @@ update_object_props_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vec
 				if _, ok3 := sphere.albedo.(core.NoiseTexture); !ok3 {
 					before := sphere
 					sphere.albedo = core.NoiseTexture{scale = 4.0}
+					sphere.texture_kind = .Constant
+					sphere.image_path = ""
 					SetSceneSphere(ev.scene_mgr, ev.selected_idx, sphere)
 					edit_history_push(&app.edit_history, ModifySphereAction{idx = ev.selected_idx, before = before, after = sphere})
 					mark_scene_dirty(app)
@@ -848,6 +852,8 @@ update_object_props_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vec
 				if _, ok3 := sphere.albedo.(core.MarbleTexture); !ok3 {
 					before := sphere
 					sphere.albedo = core.MarbleTexture{scale = 4.0}
+					sphere.texture_kind = .Constant
+					sphere.image_path = ""
 					SetSceneSphere(ev.scene_mgr, ev.selected_idx, sphere)
 					edit_history_push(&app.edit_history, ModifySphereAction{idx = ev.selected_idx, before = before, after = sphere})
 					mark_scene_dirty(app)
@@ -866,6 +872,8 @@ update_object_props_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vec
 			if ok2 {
 				before := sphere
 				sphere.albedo = core.ImageTexture{path = img_path}
+				sphere.texture_kind = .Image
+				sphere.image_path = img_path
 				app_ensure_image_cached(app, img_path)
 				SetSceneSphere(ev.scene_mgr, ev.selected_idx, sphere)
 				edit_history_push(&app.edit_history, ModifySphereAction{idx = ev.selected_idx, before = before, after = sphere})
@@ -880,6 +888,8 @@ update_object_props_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vec
 		if sphere.material_kind == .Lambertian && lo.has_image && rl.CheckCollisionPointRec(mouse, lo.btn_clear) {
 			before := sphere
 			sphere.albedo = core.ConstantTexture{color = {0.5, 0.5, 0.5}}
+			sphere.texture_kind = .Constant
+			sphere.image_path = ""
 			SetSceneSphere(ev.scene_mgr, ev.selected_idx, sphere)
 			edit_history_push(&app.edit_history, ModifySphereAction{idx = ev.selected_idx, before = before, after = sphere})
 			mark_scene_dirty(app)

--- a/persistence/scene_io.odin
+++ b/persistence/scene_io.odin
@@ -22,15 +22,16 @@ SceneCamera :: struct {
 }
 
 SceneMaterial :: struct {
-	material_type: string  `json:"type"`,
-	albedo:        [3]f32  `json:"albedo,omitempty"`,
-	image_path:    string  `json:"image_path,omitempty"`,
-	// texture_kind selects the Lambertian procedural texture: "constant" (default), "noise", "marble".
-	// When empty, behaviour falls back: if image_path non-empty → image, else → constant colour.
-	texture_kind:  string  `json:"texture_kind,omitempty"`,
-	noise_scale:   f32    `json:"noise_scale,omitempty"`,
-	fuzz:          f32    `json:"fuzz,omitempty"`,
-	ref_idx:       f32    `json:"ref_idx,omitempty"`,
+	material_type:     string  `json:"type"`,
+	albedo:            [3]f32  `json:"albedo,omitempty"`,
+	image_path:        string  `json:"image_path,omitempty"`,
+	// texture_kind: "constant" (default), "checker", "image", "noise", "marble". Missing → constant (backward compat).
+	texture_kind:      string  `json:"texture_kind,omitempty"`,
+	checker_scale:     f32     `json:"checker_scale,omitempty"`,
+	checker_color_odd: [3]f32  `json:"checker_color_odd,omitempty"`,
+	noise_scale:       f32     `json:"noise_scale,omitempty"`,
+	fuzz:              f32     `json:"fuzz,omitempty"`,
+	ref_idx:           f32     `json:"ref_idx,omitempty"`,
 }
 
 SceneObject :: struct {
@@ -186,8 +187,11 @@ load_scene :: proc(
 scene_material_to_material :: proc(s: ^SceneMaterial, scene_dir: string, image_cache: ^map[string]^rt.Texture_Image = nil) -> rt.material {
 	switch s.material_type {
 	case "lambertian":
-		// texture_kind overrides when present; otherwise fall back to legacy image_path logic.
+		// texture_kind: missing or "constant" → constant (backward compat); "checker", "image", "noise", "marble".
 		switch s.texture_kind {
+		case "checker":
+			scale := s.checker_scale != 0 ? s.checker_scale : 1.0
+			return rt.material(rt.lambertian{albedo = rt.CheckerTexture{scale = scale, even = s.albedo, odd = s.checker_color_odd}})
 		case "noise":
 			scale := s.noise_scale != 0 ? s.noise_scale : 4.0
 			return rt.material(rt.lambertian{albedo = rt.NoiseTexture{scale = scale}})
@@ -195,7 +199,7 @@ scene_material_to_material :: proc(s: ^SceneMaterial, scene_dir: string, image_c
 			scale := s.noise_scale != 0 ? s.noise_scale : 4.0
 			return rt.material(rt.lambertian{albedo = rt.MarbleTexture{scale = scale}})
 		}
-		// Legacy / image path
+		// "image" or legacy: image_path non-empty → image if cache has it
 		if len(s.image_path) > 0 && image_cache != nil {
 			resolved := _scene_resolve_image_path(scene_dir, s.image_path)
 			defer delete(resolved)
@@ -204,6 +208,7 @@ scene_material_to_material :: proc(s: ^SceneMaterial, scene_dir: string, image_c
 				return rt.material(rt.lambertian{albedo = rt.ImageTextureRuntime{path = strings.clone(resolved), image = img}})
 			}
 		}
+		// constant (default) or image miss: solid colour
 		return rt.material(rt.lambertian{albedo = rt.ConstantTexture{color = s.albedo}})
 	case "metal":
 		return rt.material(rt.metallic{albedo = s.albedo, fuzz = s.fuzz})
@@ -236,6 +241,9 @@ save_scene :: proc(path: string, r_camera: ^rt.Camera, r_world: [dynamic]rt.Obje
 	}
 	defer delete(scene.objects)
 
+	scene_dir := filepath.dir(path)
+	defer delete(scene_dir)
+
 	for obj in r_world {
 		switch o in obj {
 		case rt.Sphere:
@@ -244,7 +252,7 @@ save_scene :: proc(path: string, r_camera: ^rt.Camera, r_world: [dynamic]rt.Obje
 				center      = o.center,
 				center1     = o.center1,
 				radius      = o.radius,
-				material    = material_to_scene_material(o.material),
+				material    = material_to_scene_material(o.material, scene_dir),
 				is_moving   = o.is_moving,
 			})
 		case rt.Quad:
@@ -253,7 +261,7 @@ save_scene :: proc(path: string, r_camera: ^rt.Camera, r_world: [dynamic]rt.Obje
 				q           = o.Q,
 				u           = o.u,
 				v           = o.v,
-				material    = material_to_scene_material(o.material),
+				material    = material_to_scene_material(o.material, scene_dir),
 			})
 		}
 	}
@@ -265,6 +273,12 @@ save_scene :: proc(path: string, r_camera: ^rt.Camera, r_world: [dynamic]rt.Obje
 	}
 	defer delete(data)
 
+	for &obj in scene.objects {
+		if len(obj.material.image_path) > 0 {
+			delete(obj.material.image_path)
+		}
+	}
+
 	f, open_err := os.open(path, os.O_CREATE | os.O_WRONLY | os.O_TRUNC, 0o644)
 	if open_err != os.ERROR_NONE {
 		fmt.fprintf(os.stderr, "Scene write error: %s\n", path)
@@ -275,7 +289,9 @@ save_scene :: proc(path: string, r_camera: ^rt.Camera, r_world: [dynamic]rt.Obje
 	return true
 }
 
-material_to_scene_material :: proc(m: rt.material) -> SceneMaterial {
+// material_to_scene_material converts rt.material to JSON-friendly SceneMaterial.
+// scene_dir is the directory of the scene file; image paths are stored relative to it (absolute paths → basename).
+material_to_scene_material :: proc(m: rt.material, scene_dir: string) -> SceneMaterial {
 	switch mat in m {
 	case rt.lambertian:
 		switch tex in mat.albedo {
@@ -283,24 +299,42 @@ material_to_scene_material :: proc(m: rt.material) -> SceneMaterial {
 			return SceneMaterial{material_type = "lambertian", texture_kind = "noise", noise_scale = tex.scale}
 		case rt.MarbleTexture:
 			return SceneMaterial{material_type = "lambertian", texture_kind = "marble", noise_scale = tex.scale}
+		case rt.CheckerTexture:
+			return SceneMaterial{
+				material_type     = "lambertian",
+				texture_kind      = "checker",
+				albedo            = tex.even,
+				checker_scale     = tex.scale,
+				checker_color_odd = tex.odd,
+			}
 		case rt.ImageTextureRuntime:
 			if len(tex.path) > 0 {
+				// Store path relative to scene file; absolute or unrelated → basename.
+				rel_path := tex.path
+				if len(scene_dir) > 0 {
+					if rel, rel_err := filepath.rel(scene_dir, tex.path); rel_err == nil {
+						rel_path = rel
+					} else {
+						rel_path = filepath.base(tex.path)
+					}
+				}
 				return SceneMaterial{
 					material_type = "lambertian",
+					texture_kind  = "image",
 					albedo        = rt.texture_value_runtime(mat.albedo, 0, 0, {0, 0, 0}),
-					image_path    = tex.path,
+					image_path    = rel_path,
 				}
 			}
-		case rt.ConstantTexture: // handled by fallthrough below
-		case rt.CheckerTexture:  // handled by fallthrough below
+		case rt.ConstantTexture:
+			return SceneMaterial{material_type = "lambertian", texture_kind = "constant", albedo = tex.color}
 		}
-		// ConstantTexture / CheckerTexture / fallback: sample at origin for a representative colour.
-		return SceneMaterial{material_type = "lambertian", albedo = rt.texture_value_runtime(mat.albedo, 0, 0, {0, 0, 0})}
+		// fallback
+		return SceneMaterial{material_type = "lambertian", texture_kind = "constant", albedo = rt.texture_value_runtime(mat.albedo, 0, 0, {0, 0, 0})}
 	case rt.metallic:
 		return SceneMaterial{material_type = "metal", albedo = mat.albedo, fuzz = mat.fuzz}
 	case rt.dielectric:
 		return SceneMaterial{material_type = "dielectric", ref_idx = mat.ref_idx}
 	case:
-		return SceneMaterial{material_type = "lambertian", albedo = [3]f32{0.5, 0.5, 0.5}}
+		return SceneMaterial{material_type = "lambertian", texture_kind = "constant", albedo = [3]f32{0.5, 0.5, 0.5}}
 	}
 }

--- a/raytrace/scene_build.odin
+++ b/raytrace/scene_build.odin
@@ -1,6 +1,7 @@
 package raytrace
 
 import "core:fmt"
+import "core:strings"
 import "RT_Weekend:core"
 when !VERBOSE_OUTPUT {
 	@(private)
@@ -11,6 +12,7 @@ when !VERBOSE_OUTPUT {
 
 // sphere_to_scene_sphere converts a single Sphere to core.SceneSphere (material, albedo, etc.).
 // Used by LoadFromWorld to preserve world order when rebuilding the editor object list.
+// Sets texture_kind, checker_scale, checker_color_odd, image_path for Lambertian persistence.
 sphere_to_scene_sphere :: proc(s: Sphere) -> core.SceneSphere {
 	ss := core.SceneSphere{center = s.center, center1 = s.center1, radius = s.radius, is_moving = s.is_moving}
 	switch m in s.material {
@@ -18,14 +20,22 @@ sphere_to_scene_sphere :: proc(s: Sphere) -> core.SceneSphere {
 		ss.material_kind = .Lambertian
 		switch a in m.albedo {
 		case ConstantTexture:
+			ss.texture_kind = .Constant
 			ss.albedo = core.Texture(a)
 		case CheckerTexture:
+			ss.texture_kind = .Checker
+			ss.checker_scale = a.scale
+			ss.checker_color_odd = a.odd
 			ss.albedo = core.Texture(a)
 		case ImageTextureRuntime:
+			ss.texture_kind = .Image
+			ss.image_path = a.path
 			ss.albedo = core.ImageTexture{path = a.path}
 		case NoiseTexture:
+			ss.texture_kind = .Constant
 			ss.albedo = core.Texture(core.NoiseTexture(a))
 		case MarbleTexture:
+			ss.texture_kind = .Constant
 			ss.albedo = core.Texture(core.MarbleTexture(a))
 		}
 	case metallic:
@@ -60,12 +70,12 @@ convert_world_to_edit_spheres :: proc(world: []Object) -> [dynamic]core.SceneSph
 // build_world_from_scene converts shared scene spheres to raytrace Objects.
 // When include_ground is true, prepends a ground plane using the given ground_texture (value).
 // Caller passes default grey (e.g. ConstantTexture{0.5,0.5,0.5}) when no custom ground is desired.
-// image_cache: when a sphere's albedo is core.ImageTexture(path), it is looked up here; if present, Lambertian gets ImageTextureRuntime(path, ptr). If nil or path missing, fallback to grey ConstantTexture.
+// image_cache: when non-nil, Lambertian .Image textures are looked up here; on miss we try to load and insert. If nil or load fails, use magenta fallback.
 // Caller owns and must delete the returned dynamic array.
 build_world_from_scene :: proc(
 	scene_objects: []core.SceneSphere,
 	ground_texture: Texture,
-	image_cache: map[string]^Texture_Image = nil,
+	image_cache: ^map[string]^Texture_Image = nil,
 	include_ground: bool = true,
 ) -> [dynamic]Object {
 	world := make([dynamic]Object)
@@ -94,42 +104,112 @@ build_world_from_scene :: proc(
 		}))
 	}
 
+	MAGENTA_FALLBACK :: [3]f32{1, 0, 1}
+
 	for s in scene_objects {
 		mat: material
 		switch s.material_kind {
 		case .Lambertian:
 			albedo_rtex: RTexture
-			switch a in s.albedo {
-			case ConstantTexture:
-				albedo_rtex = a
-			case CheckerTexture:
-				albedo_rtex = a
-			case core.NoiseTexture:
-				albedo_rtex = NoiseTexture(a)
-			case core.MarbleTexture:
-				albedo_rtex = MarbleTexture(a)
-			case core.ImageTexture:
-				if image_cache != nil {
-					if img := image_cache[a.path]; img != nil {
+			// Prefer texture_kind for scene-driven conversion; fall back to albedo union for legacy/Noise/Marble.
+			switch s.texture_kind {
+			case .Constant:
+				switch a in s.albedo {
+				case ConstantTexture:
+					albedo_rtex = a
+				case CheckerTexture:
+					albedo_rtex = ConstantTexture{color = a.even}
+				case core.NoiseTexture:
+					albedo_rtex = NoiseTexture(a)
+				case core.MarbleTexture:
+					albedo_rtex = MarbleTexture(a)
+				case core.ImageTexture:
+					albedo_rtex = ConstantTexture{color = {0.5, 0.5, 0.5}}
+				case:
+					albedo_rtex = ConstantTexture{color = {0.5, 0.5, 0.5}}
+				}
+			case .Checker:
+				even := [3]f32{0.5, 0.5, 0.5}
+				switch a in s.albedo {
+				case ConstantTexture:     even = a.color
+				case CheckerTexture:      even = a.even
+				case core.NoiseTexture:   {}
+				case core.MarbleTexture:  {}
+				case core.ImageTexture:   {}
+				case:                     {}
+				}
+				scale := s.checker_scale
+				if scale <= 0 { scale = 1.0 }
+				albedo_rtex = CheckerTexture{scale = scale, even = even, odd = s.checker_color_odd}
+			case .Image:
+				path := s.image_path
+				if len(path) == 0 {
+					if a, ok := s.albedo.(core.ImageTexture); ok { path = a.path }
+				}
+				if image_cache != nil && len(path) > 0 {
+					if img := image_cache[path]; img != nil {
 						when VERBOSE_OUTPUT {
 							fmt.printf("[SceneBuild] Image texture cache hit path=%q (%dx%d)\n",
-								a.path, texture_image_width(img), texture_image_height(img))
+								path, texture_image_width(img), texture_image_height(img))
 						}
-						albedo_rtex = ImageTextureRuntime{path = a.path, image = img}
+						albedo_rtex = ImageTextureRuntime{path = path, image = img}
 					} else {
-						when VERBOSE_OUTPUT {
-							fmt.printf("[SceneBuild] Image texture cache miss path=%q; using gray fallback\n", a.path)
+						img := new(Texture_Image)
+						img^ = texture_image_init()
+						if texture_image_load(img, path) {
+							image_cache[strings.clone(path)] = img
+							albedo_rtex = ImageTextureRuntime{path = path, image = img}
+						} else {
+							when VERBOSE_OUTPUT {
+								fmt.printf("[SceneBuild] Image texture load failed path=%q; using magenta fallback\n", path)
+							}
+							texture_image_destroy(img)
+							free(img)
+							albedo_rtex = ConstantTexture{color = MAGENTA_FALLBACK}
 						}
-						albedo_rtex = ConstantTexture{color = {0.5, 0.5, 0.5}}
 					}
 				} else {
 					when VERBOSE_OUTPUT {
-						fmt.printf("[SceneBuild] Image texture has nil cache path=%q; using gray fallback\n", a.path)
+						if image_cache == nil {
+							fmt.printf("[SceneBuild] Image texture nil cache path=%q; using magenta fallback\n", path)
+						}
 					}
-					albedo_rtex = ConstantTexture{color = {0.5, 0.5, 0.5}}
+					albedo_rtex = ConstantTexture{color = MAGENTA_FALLBACK}
 				}
 			case:
-				albedo_rtex = ConstantTexture{color = {0.5, 0.5, 0.5}}
+				// Legacy: derive from albedo union
+				switch a in s.albedo {
+				case ConstantTexture:
+					albedo_rtex = a
+				case CheckerTexture:
+					albedo_rtex = a
+				case core.NoiseTexture:
+					albedo_rtex = NoiseTexture(a)
+				case core.MarbleTexture:
+					albedo_rtex = MarbleTexture(a)
+				case core.ImageTexture:
+					path := a.path
+					if image_cache != nil && len(path) > 0 {
+						if img := image_cache[path]; img != nil {
+							albedo_rtex = ImageTextureRuntime{path = path, image = img}
+						} else {
+							img := new(Texture_Image)
+							img^ = texture_image_init()
+							if texture_image_load(img, path) {
+								image_cache[strings.clone(path)] = img
+								albedo_rtex = ImageTextureRuntime{path = path, image = img}
+							} else {
+								texture_image_destroy(img)
+								free(img)
+								albedo_rtex = ConstantTexture{color = MAGENTA_FALLBACK}
+							}
+						}
+					} else {
+						albedo_rtex = ConstantTexture{color = MAGENTA_FALLBACK}
+					}
+				case:
+					albedo_rtex = ConstantTexture{color = {0.5, 0.5, 0.5}}
+				}
 			}
 			mat = material(lambertian{albedo = albedo_rtex})
 		case .Metallic:


### PR DESCRIPTION
- Added TextureKind enum to define Lambertian texture types: Constant, Checker, and Image.
- Updated SceneSphere struct to include texture_kind, checker_scale, checker_color_odd, and image_path for improved texture management.
- Modified scene material serialization in persistence/scene_io.odin to support new texture fields.
- Refactored build_world_from_scene and sphere_to_scene_sphere to utilize new texture properties for better scene persistence and rendering.
- Updated editor panel logic to set texture properties when modifying sphere materials, ensuring consistent behavior across the application.