### PR TITLE
Introduce PanelRegistry: declare panels once, wire automatically (#122)

### DIFF
--- a/editor/AGENTS.md
+++ b/editor/AGENTS.md
@@ -59,12 +59,13 @@ Old configs using the legacy IDs load correctly via `_panel_id_translate` in `ap
 
 ## How to add a new panel
 
+Panels are declared once in `PANEL_REGISTRY` (`panel_registry.odin`). `run_app`, `register_all_commands`, and `get_menus_dynamic` all drive off that table automatically.
+
 1. Create `panel_<name>.odin` with `draw_<name>_content` and optionally `update_<name>_content` procs.
 2. Define `PANEL_ID_<NAME> :: "<name>"` in `app.odin`.
 3. Optionally add `<Name>PanelState` to `App` struct (field prefix `e_`).
-4. Call `make_panel(PanelDesc{...})` in `run_app()` and `app_add_panel(&app, ...)`.
-5. Add a `CMD_VIEW_<NAME>` constant to `core_commands.odin` and register `cmd_action_view_<name>` / `cmd_checked_view_<name>` in `register_all_commands` (core_cmd_actions.odin).
-6. Add the menu entry in `get_menus_dynamic` (ui_menu_bar.odin).
+4. Define `CMD_VIEW_<NAME>` in `core_commands.odin`; add `cmd_action_view_<name>` / `cmd_checked_view_<name>` stubs in `core_cmd_actions.odin`.
+5. Add one `PanelDescriptor` entry to `PANEL_REGISTRY` in `panel_registry.odin` — that's it.
 
 **Edit View split (shared / state / UI):**
 

--- a/editor/app.odin
+++ b/editor/app.odin
@@ -661,109 +661,21 @@ run_app :: proc(
         delete(app.r_samples_input)
     }
 
-    app_add_panel(&app, make_panel(PanelDesc{
-        id             = PANEL_ID_RENDER,
-        title          = "Render Preview",
-        rect           = rl.Rectangle{10, 30, 820, 700},
-        min_size       = rl.Vector2{260, 200},
-        visible        = true,
-        draw_content   = draw_render_content,
-        update_content = update_render_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id             = PANEL_ID_STATS,
-        title          = "Stats",
-        rect           = rl.Rectangle{840, 30, 430, 220},
-        min_size       = rl.Vector2{180, 140},
-        visible        = true,
-        draw_content   = draw_stats_content,
-        update_content = update_stats_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id                 = PANEL_ID_CONSOLE,
-        title              = "Console",
-        rect               = rl.Rectangle{840, 240, 430, 470},
-        min_size           = rl.Vector2{180, 100},
-        visible            = true,
-        closeable          = true,
-        detachable         = true,
-        dim_when_maximized = true,
-        draw_content       = draw_console_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id           = PANEL_ID_SYSTEM_INFO,
-        title        = "System Info",
-        rect         = rl.Rectangle{840, 470, 430, 220},
-        min_size     = rl.Vector2{180, 140},
-        visible      = true,
-        closeable    = true,
-        detachable   = true,
-        draw_content = draw_system_info_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id             = PANEL_ID_VIEWPORT,
-        title          = "Viewport",
-        rect           = rl.Rectangle{10, 850, 820, 700},
-        min_size       = rl.Vector2{300, 250},
-        visible        = true,
-        closeable      = true,
-        detachable     = true,
-        draw_content   = draw_viewport_content,
-        update_content = update_viewport_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id             = PANEL_ID_CAMERA,
-        title          = "Camera",
-        rect           = rl.Rectangle{840, 700, 250, 220},
-        min_size       = rl.Vector2{200, 180},
-        visible        = true,
-        closeable      = true,
-        detachable     = true,
-        draw_content   = draw_camera_panel_content,
-        update_content = update_camera_panel_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id             = PANEL_ID_DETAILS,
-        title          = "Details",
-        rect           = rl.Rectangle{1100, 30, 260, 340},
-        min_size       = rl.Vector2{240, 240},
-        visible        = true,
-        closeable      = true,
-        detachable     = true,
-        draw_content   = draw_details_content,
-        update_content = update_details_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id           = PANEL_ID_CAMERA_PREVIEW,
-        title        = "Camera Preview",
-        rect         = rl.Rectangle{840, 920, 250, 180},
-        min_size     = rl.Vector2{160, 120},
-        visible      = true,
-        closeable    = true,
-        detachable   = true,
-        draw_content = draw_camera_preview_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id             = PANEL_ID_OUTLINER,
-        title          = "World Outliner",
-        rect           = rl.Rectangle{840, 700, 260, 300},
-        min_size       = rl.Vector2{180, 150},
-        visible        = true,
-        closeable      = true,
-        detachable     = true,
-        draw_content   = draw_outliner_content,
-        update_content = update_outliner_content,
-    }))
-    app_add_panel(&app, make_panel(PanelDesc{
-        id           = PANEL_ID_TEXTURE_VIEW,
-        title        = "Texture View",
-        rect         = rl.Rectangle{1100, 380, 260, 280},
-        min_size     = rl.Vector2{200, 200},
-        visible      = true,
-        closeable    = true,
-        detachable   = true,
-        draw_content = draw_texture_view_content,
-    }))
+    for desc in PANEL_REGISTRY {
+        app_add_panel(&app, make_panel(PanelDesc{
+            id                 = desc.panel_id,
+            title              = desc.title,
+            rect               = desc.default_rect,
+            min_size           = desc.min_size,
+            visible            = desc.visible,
+            closeable          = desc.closeable,
+            detachable         = desc.detachable,
+            dim_when_maximized = desc.dim_when_maximized,
+            style              = desc.style,
+            draw_content       = desc.draw_content,
+            update_content     = desc.update_content,
+        }))
+    }
 
     if initial_editor_layout != nil {
         apply_editor_layout(&app, initial_editor_layout)

--- a/editor/core_cmd_actions.odin
+++ b/editor/core_cmd_actions.odin
@@ -550,17 +550,15 @@ register_all_commands :: proc(app: ^App) {
     cmd_register(cmd_reg, Command{id = CMD_FILE_SAVE_AS, label = "Save As…", shortcut = "",       action = cmd_action_file_save_as})
     cmd_register(cmd_reg, Command{id = CMD_FILE_EXIT,    label = "Exit",     shortcut = "Alt+F4", action = cmd_action_file_exit})
 
-    // View — panels
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_RENDER,  label = "Render Preview", action = cmd_action_view_render,  checked_proc = cmd_checked_view_render})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_STATS,   label = "Stats",          action = cmd_action_view_stats,   checked_proc = cmd_checked_view_stats})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_LOG,      label = "Console",        action = cmd_action_view_log,      checked_proc = cmd_checked_view_log})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_SYSINFO,  label = "System Info",    action = cmd_action_view_sysinfo,  checked_proc = cmd_checked_view_sysinfo})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_EDIT,     label = "Viewport",       action = cmd_action_view_edit,     checked_proc = cmd_checked_view_edit})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_CAMERA,   label = "Camera",         action = cmd_action_view_camera,   checked_proc = cmd_checked_view_camera})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_PROPS,    label = "Details",        action = cmd_action_view_props,    checked_proc = cmd_checked_view_props})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_PREVIEW,  label = "Camera Preview", action = cmd_action_view_preview,  checked_proc = cmd_checked_view_preview})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_TEXTURE,  label = "Texture View",   action = cmd_action_view_texture,  checked_proc = cmd_checked_view_texture})
-    cmd_register(cmd_reg, Command{id = CMD_VIEW_OUTLINER, label = "World Outliner", action = cmd_action_view_outliner, checked_proc = cmd_checked_view_outliner})
+    // View — panels (driven by PANEL_REGISTRY)
+    for desc in PANEL_REGISTRY {
+        cmd_register(cmd_reg, Command{
+            id           = desc.cmd_id,
+            label        = string(desc.cmd_label),
+            action       = desc.cmd_action,
+            checked_proc = desc.cmd_checked,
+        })
+    }
 
     // View — presets
     cmd_register(cmd_reg, Command{id = CMD_VIEW_PRESET_DEFAULT, label = "Default",         action = cmd_action_preset_default})

--- a/editor/panel_registry.odin
+++ b/editor/panel_registry.odin
@@ -1,0 +1,185 @@
+// panel_registry.odin — Single source of truth for all floating panels.
+// Each PanelDescriptor captures default geometry, visibility flags, content callbacks,
+// and the View-menu command that toggles the panel.  Adding a new panel requires only:
+//   1. Create panel_<name>.odin with draw_<name>_content / update_<name>_content procs.
+//   2. Define PANEL_ID_<NAME> :: "<name>" in app.odin.
+//   3. Optionally add <Name>PanelState to App (prefix e_).
+//   4. Add one PanelDescriptor entry to PANEL_REGISTRY below.
+//   5. Define CMD_VIEW_<NAME> in core_commands.odin; add cmd_action/cmd_checked stubs in core_cmd_actions.odin.
+// That's it — run_app, register_all_commands, and get_menus_dynamic all drive off this table.
+
+package editor
+
+import rl "vendor:raylib"
+
+// PanelDescriptor is the static description of a floating panel and its View-menu command.
+PanelDescriptor :: struct {
+    // Panel identity & chrome
+    panel_id:           string,
+    title:              cstring,
+    default_rect:       rl.Rectangle,
+    min_size:           rl.Vector2,
+    visible:            bool,
+    closeable:          bool,
+    detachable:         bool,
+    dim_when_maximized: bool,
+    style:              ^PanelStyle,
+
+    // Content callbacks (nil = no content / no input)
+    draw_content:   proc(app: ^App, content: rl.Rectangle),
+    update_content: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vector2, lmb: bool, lmb_pressed: bool),
+
+    // View-menu command wiring
+    cmd_id:      string,
+    cmd_label:   cstring,
+    cmd_action:  proc(app: ^App),
+    cmd_checked: proc(app: ^App) -> bool,
+}
+
+// PANEL_REGISTRY is the single source of truth for all floating panels in the editor.
+// Order determines the default stacking order (first = bottom-most).
+PANEL_REGISTRY :: [?]PanelDescriptor{
+    {
+        panel_id     = PANEL_ID_RENDER,
+        title        = "Render Preview",
+        default_rect = rl.Rectangle{10, 30, 820, 700},
+        min_size     = rl.Vector2{260, 200},
+        visible      = true,
+        draw_content   = draw_render_content,
+        update_content = update_render_content,
+        cmd_id      = CMD_VIEW_RENDER,
+        cmd_label   = "Render Preview",
+        cmd_action  = cmd_action_view_render,
+        cmd_checked = cmd_checked_view_render,
+    },
+    {
+        panel_id     = PANEL_ID_STATS,
+        title        = "Stats",
+        default_rect = rl.Rectangle{840, 30, 430, 220},
+        min_size     = rl.Vector2{180, 140},
+        visible      = true,
+        draw_content   = draw_stats_content,
+        update_content = update_stats_content,
+        cmd_id      = CMD_VIEW_STATS,
+        cmd_label   = "Stats",
+        cmd_action  = cmd_action_view_stats,
+        cmd_checked = cmd_checked_view_stats,
+    },
+    {
+        panel_id           = PANEL_ID_CONSOLE,
+        title              = "Console",
+        default_rect       = rl.Rectangle{840, 240, 430, 470},
+        min_size           = rl.Vector2{180, 100},
+        visible            = true,
+        closeable          = true,
+        detachable         = true,
+        dim_when_maximized = true,
+        draw_content = draw_console_content,
+        cmd_id      = CMD_VIEW_LOG,
+        cmd_label   = "Console",
+        cmd_action  = cmd_action_view_log,
+        cmd_checked = cmd_checked_view_log,
+    },
+    {
+        panel_id     = PANEL_ID_SYSTEM_INFO,
+        title        = "System Info",
+        default_rect = rl.Rectangle{840, 470, 430, 220},
+        min_size     = rl.Vector2{180, 140},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content = draw_system_info_content,
+        cmd_id      = CMD_VIEW_SYSINFO,
+        cmd_label   = "System Info",
+        cmd_action  = cmd_action_view_sysinfo,
+        cmd_checked = cmd_checked_view_sysinfo,
+    },
+    {
+        panel_id     = PANEL_ID_VIEWPORT,
+        title        = "Viewport",
+        default_rect = rl.Rectangle{10, 850, 820, 700},
+        min_size     = rl.Vector2{300, 250},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content   = draw_viewport_content,
+        update_content = update_viewport_content,
+        cmd_id      = CMD_VIEW_EDIT,
+        cmd_label   = "Viewport",
+        cmd_action  = cmd_action_view_edit,
+        cmd_checked = cmd_checked_view_edit,
+    },
+    {
+        panel_id     = PANEL_ID_CAMERA,
+        title        = "Camera",
+        default_rect = rl.Rectangle{840, 700, 250, 220},
+        min_size     = rl.Vector2{200, 180},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content   = draw_camera_panel_content,
+        update_content = update_camera_panel_content,
+        cmd_id      = CMD_VIEW_CAMERA,
+        cmd_label   = "Camera",
+        cmd_action  = cmd_action_view_camera,
+        cmd_checked = cmd_checked_view_camera,
+    },
+    {
+        panel_id     = PANEL_ID_DETAILS,
+        title        = "Details",
+        default_rect = rl.Rectangle{1100, 30, 260, 340},
+        min_size     = rl.Vector2{240, 240},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content   = draw_details_content,
+        update_content = update_details_content,
+        cmd_id      = CMD_VIEW_PROPS,
+        cmd_label   = "Details",
+        cmd_action  = cmd_action_view_props,
+        cmd_checked = cmd_checked_view_props,
+    },
+    {
+        panel_id     = PANEL_ID_CAMERA_PREVIEW,
+        title        = "Camera Preview",
+        default_rect = rl.Rectangle{840, 920, 250, 180},
+        min_size     = rl.Vector2{160, 120},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content = draw_camera_preview_content,
+        cmd_id      = CMD_VIEW_PREVIEW,
+        cmd_label   = "Camera Preview",
+        cmd_action  = cmd_action_view_preview,
+        cmd_checked = cmd_checked_view_preview,
+    },
+    {
+        panel_id     = PANEL_ID_OUTLINER,
+        title        = "World Outliner",
+        default_rect = rl.Rectangle{840, 700, 260, 300},
+        min_size     = rl.Vector2{180, 150},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content   = draw_outliner_content,
+        update_content = update_outliner_content,
+        cmd_id      = CMD_VIEW_OUTLINER,
+        cmd_label   = "World Outliner",
+        cmd_action  = cmd_action_view_outliner,
+        cmd_checked = cmd_checked_view_outliner,
+    },
+    {
+        panel_id     = PANEL_ID_TEXTURE_VIEW,
+        title        = "Texture View",
+        default_rect = rl.Rectangle{1100, 380, 260, 280},
+        min_size     = rl.Vector2{200, 200},
+        visible      = true,
+        closeable    = true,
+        detachable   = true,
+        draw_content = draw_texture_view_content,
+        cmd_id      = CMD_VIEW_TEXTURE,
+        cmd_label   = "Texture View",
+        cmd_action  = cmd_action_view_texture,
+        cmd_checked = cmd_checked_view_texture,
+    },
+}

--- a/editor/ui_menu_bar.odin
+++ b/editor/ui_menu_bar.odin
@@ -41,17 +41,14 @@ get_menus_dynamic :: proc(app: ^App) -> []MenuDyn {
 
     // Build View entries as a dynamic slice so user presets can be appended.
     view_entries := make([dynamic]MenuEntryDyn, context.temp_allocator)
+    for desc in PANEL_REGISTRY {
+        append(&view_entries, MenuEntryDyn{
+            label   = string(desc.cmd_label),
+            cmd_id  = desc.cmd_id,
+            checked = cmd_is_checked(app, desc.cmd_id),
+        })
+    }
     append(&view_entries,
-        MenuEntryDyn{label = "Render Preview", cmd_id = CMD_VIEW_RENDER,  checked = cmd_is_checked(app, CMD_VIEW_RENDER)},
-        MenuEntryDyn{label = "Stats",          cmd_id = CMD_VIEW_STATS,   checked = cmd_is_checked(app, CMD_VIEW_STATS)},
-        MenuEntryDyn{label = "Console",         cmd_id = CMD_VIEW_LOG,      checked = cmd_is_checked(app, CMD_VIEW_LOG)},
-        MenuEntryDyn{label = "System Info",    cmd_id = CMD_VIEW_SYSINFO,  checked = cmd_is_checked(app, CMD_VIEW_SYSINFO)},
-        MenuEntryDyn{label = "Viewport",       cmd_id = CMD_VIEW_EDIT,     checked = cmd_is_checked(app, CMD_VIEW_EDIT)},
-        MenuEntryDyn{label = "Camera",         cmd_id = CMD_VIEW_CAMERA,   checked = cmd_is_checked(app, CMD_VIEW_CAMERA)},
-        MenuEntryDyn{label = "Details",        cmd_id = CMD_VIEW_PROPS,    checked = cmd_is_checked(app, CMD_VIEW_PROPS)},
-        MenuEntryDyn{label = "Camera Preview", cmd_id = CMD_VIEW_PREVIEW,  checked = cmd_is_checked(app, CMD_VIEW_PREVIEW)},
-        MenuEntryDyn{label = "Texture View",   cmd_id = CMD_VIEW_TEXTURE,  checked = cmd_is_checked(app, CMD_VIEW_TEXTURE)},
-        MenuEntryDyn{label = "World Outliner", cmd_id = CMD_VIEW_OUTLINER, checked = cmd_is_checked(app, CMD_VIEW_OUTLINER)},
         MenuEntryDyn{separator = true},
         MenuEntryDyn{label = "Default Layout",        cmd_id = CMD_VIEW_PRESET_DEFAULT},
         MenuEntryDyn{label = "Rendering Focus Layout", cmd_id = CMD_VIEW_PRESET_RENDER},


### PR DESCRIPTION
## Summary

- Adds `editor/panel_registry.odin` with `PanelDescriptor` struct and `PANEL_REGISTRY` constant array (10 entries)
- Each descriptor captures panel ID, title, default geometry, visibility flags, content callbacks, and the View-menu command that toggles it
- Replaces 10 explicit `make_panel` calls in `run_app` with a loop over `PANEL_REGISTRY`
- Replaces 10 explicit `cmd_register` panel-view calls in `register_all_commands` with a loop
- Replaces 10 explicit `append` panel entries in `get_menus_dynamic` with a loop
- Updates `AGENTS.md` "How to add a new panel" from a 6-step guide to 5 steps

## Test plan

- [ ] `make debug` compiles without errors
- [ ] All 10 panels appear in the View menu with correct labels and checkmarks
- [ ] Opening/closing panels via View menu works correctly
- [ ] Panel titles in chrome match PANEL_REGISTRY entries
- [ ] Adding a hypothetical new panel only requires one registry entry + one content file

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)