### PR TITLE
Fix GPU render stall: async readback via double-PBO (#129)

### DIFF
--- a/raytrace/gpu_backend.odin
+++ b/raytrace/gpu_backend.odin
@@ -371,6 +371,16 @@ gpu_backend_init :: proc(
     gl.BufferData(gl.SHADER_STORAGE_BUFFER, output_total, raw_data(zeroes), gl.DYNAMIC_COPY)
     gl.BindBuffer(gl.SHADER_STORAGE_BUFFER, 0)
 
+    // Allocate two PBOs for async SSBO→CPU readback (ping-pong).
+    // STREAM_READ: written by GPU DMA, read once by CPU.
+    b.pbo_size = pixel_count * size_of([4]f32)
+    gl.GenBuffers(2, &b.pbo[0])
+    for i in 0..<2 {
+        gl.BindBuffer(gl.COPY_WRITE_BUFFER, b.pbo[i])
+        gl.BufferData(gl.COPY_WRITE_BUFFER, b.pbo_size, nil, gl.STREAM_READ)
+    }
+    gl.BindBuffer(gl.COPY_WRITE_BUFFER, 0)
+
     when VERBOSE_OUTPUT {
         fmt.printf("[GPU] Buffers ready — %d spheres, %d quads, %d volumes, %d BVH nodes, %dx%d px\n",
             len(spheres), len(quads), len(volumes), len(lin_bvh), cam.image_width, cam.image_height)
@@ -436,8 +446,29 @@ gpu_backend_dispatch :: proc(b: ^GPUBackend) {
     }
 
     // Memory barrier: all SSBO writes in the compute shader are made visible
-    // before any subsequent buffer reads (e.g. GetBufferSubData in readback).
+    // before any subsequent buffer reads or copies.
     gl.MemoryBarrier(gl.SHADER_STORAGE_BARRIER_BIT)
+
+    // Asynchronously copy the accumulation SSBO into the current PBO slot.
+    // glCopyBufferSubData enqueues a DMA transfer on the GPU timeline;
+    // the CPU returns immediately.  A fence sync marks when it completes.
+    if b.pbo[0] != 0 {
+        slot := b.pbo_frame % 2
+        // Clean up any unconsumed fence for this slot (can happen if readback
+        // was skipped while the fence was already signaled).
+        if b.pbo_fence[slot] != nil {
+            gl.DeleteSync(auto_cast b.pbo_fence[slot])
+            b.pbo_fence[slot] = nil
+        }
+        gl.BindBuffer(gl.COPY_READ_BUFFER,  b.ssbo_output)
+        gl.BindBuffer(gl.COPY_WRITE_BUFFER, b.pbo[slot])
+        gl.CopyBufferSubData(gl.COPY_READ_BUFFER, gl.COPY_WRITE_BUFFER, 0, 0, b.pbo_size)
+        gl.BindBuffer(gl.COPY_READ_BUFFER,  0)
+        gl.BindBuffer(gl.COPY_WRITE_BUFFER, 0)
+        b.pbo_sample_at_fill[slot] = b.current_sample
+        b.pbo_fence[slot]          = auto_cast gl.FenceSync(gl.SYNC_GPU_COMMANDS_COMPLETE, 0)
+        b.pbo_frame += 1
+    }
 }
 
 // ── gpu_backend_readback ─────────────────────────────────────────────────────
@@ -463,36 +494,55 @@ gpu_backend_readback :: proc(b: ^GPUBackend, out: [][4]u8) {
         }
     }
 
-    // Read the raw float accumulation buffer from GPU memory.
-    tmp := make([][4]f32, pixel_count)
-    defer delete(tmp)
+    // Async PBO readback: check whether the fence for the previous frame's PBO
+    // slot is signaled.  ClientWaitSync with timeout=0 is non-blocking — it
+    // returns immediately with TIMEOUT_EXPIRED if the GPU is still busy.
+    //
+    // Slot assignment (after dispatch has already incremented pbo_frame):
+    //   dispatch wrote to slot (pbo_frame-1) % 2  →  we read from pbo_frame % 2
+    // On the very first frame pbo_frame==0 and the slot's fence is nil, so
+    // we return early and leave out[] unchanged (black for one frame).
+    read_slot := b.pbo_frame % 2
+    fence     := b.pbo_fence[read_slot]
 
-    gl.BindBuffer(gl.SHADER_STORAGE_BUFFER, b.ssbo_output)
-    gl.GetBufferSubData(gl.SHADER_STORAGE_BUFFER, 0,
-        pixel_count * size_of([4]f32), raw_data(tmp))
-    gl.BindBuffer(gl.SHADER_STORAGE_BUFFER, 0)
+    if b.pbo[0] == 0 || fence == nil {
+        // PBOs not yet initialised, or no data ready for this slot yet.
+        return
+    }
 
-    inv := f32(1.0) / f32(max(b.current_sample, 1))
+    result := gl.ClientWaitSync(auto_cast fence, 0, 0)
+    if result == gl.TIMEOUT_EXPIRED || result == gl.WAIT_FAILED {
+        // GPU hasn't finished the DMA for this slot; skip this frame.
+        return
+    }
+
+    // Fence signalled: consume it and map the PBO for reading.
+    gl.DeleteSync(auto_cast fence)
+    b.pbo_fence[read_slot] = nil
+
+    gl.BindBuffer(gl.COPY_READ_BUFFER, b.pbo[read_slot])
+    ptr := gl.MapBufferRange(gl.COPY_READ_BUFFER, 0, b.pbo_size, gl.MAP_READ_BIT)
+    if ptr == nil {
+        gl.BindBuffer(gl.COPY_READ_BUFFER, 0)
+        return
+    }
+
+    raw := ([^][4]f32)(ptr)
+    inv := f32(1.0) / f32(max(b.pbo_sample_at_fill[read_slot], 1))
 
     for i in 0..<pixel_count {
-        // Divide by sample count to get the running average.
-        r := tmp[i][0] * inv
-        g := tmp[i][1] * inv
-        bv := tmp[i][2] * inv
-
-        // Gamma correction (γ = 2.0): sqrt maps linear light to display gamma.
-        // Mirrors linear_to_gamma in vector3.odin.
+        r  := raw[i][0] * inv
+        g  := raw[i][1] * inv
+        bv := raw[i][2] * inv
+        // Gamma correction (γ = 2.0) — mirrors linear_to_gamma in vector3.odin.
         r  = math.sqrt(clamp(r,  0, 1))
         g  = math.sqrt(clamp(g,  0, 1))
         bv = math.sqrt(clamp(bv, 0, 1))
-
-        out[i] = [4]u8{
-            u8(r  * 255.999),
-            u8(g  * 255.999),
-            u8(bv * 255.999),
-            255,
-        }
+        out[i] = [4]u8{u8(r * 255.999), u8(g * 255.999), u8(bv * 255.999), 255}
     }
+
+    gl.UnmapBuffer(gl.COPY_READ_BUFFER)
+    gl.BindBuffer(gl.COPY_READ_BUFFER, 0)
 }
 
 // ── gpu_backend_destroy ──────────────────────────────────────────────────────
@@ -515,8 +565,23 @@ gpu_backend_destroy :: proc(b: ^GPUBackend) {
             gl.DeleteTextures(1, &b.image_texs[i])
         }
     }
+    b.num_image_texs = 0
+    // Delete timer query.
     if b.timer_query != 0 {
         gl.DeleteQueries(1, &b.timer_query)
+        b.timer_query = 0
+    }
+    // Delete PBO fences and buffers.
+    for i in 0..<2 {
+        if b.pbo_fence[i] != nil {
+            gl.DeleteSync(auto_cast b.pbo_fence[i])
+            b.pbo_fence[i] = nil
+        }
+    }
+    if b.pbo[0] != 0 {
+        gl.DeleteBuffers(2, &b.pbo[0])
+        b.pbo[0] = 0
+        b.pbo[1] = 0
     }
     free(b)
 }

--- a/raytrace/gpu_types.odin
+++ b/raytrace/gpu_types.odin
@@ -50,6 +50,14 @@ GPUBackend :: struct {
     timer_query:          u32,  // GL query object; 0 = not yet created
     timer_query_pending:  bool, // true = a query was begun and not yet read back
     gpu_dispatch_total_ns: i64, // accumulated GPU execution time across all dispatches
+    // Async readback via double-PBO ping-pong.
+    // dispatch writes SSBO → pbo[pbo_frame%2] then inserts a fence.
+    // readback checks the fence for the *other* slot (1-frame lag) and maps it.
+    pbo:                [2]u32,    // two GL buffer objects
+    pbo_fence:          [2]rawptr, // GLsync handles; nil = slot unused
+    pbo_size:           int,       // bytes per PBO (width * height * 16)
+    pbo_sample_at_fill: [2]int,    // current_sample when each slot was filled
+    pbo_frame:          int,       // incremented each dispatch; slot = pbo_frame % 2
 }
 
 // ---- Step 1 ------------------------------------------------


### PR DESCRIPTION
## Summary

- Replaces the synchronous `glGetBufferSubData` call in `gpu_backend_readback` with a double-PBO ping-pong pattern, eliminating the per-frame CPU-GPU stall that caused editor freezes during GPU rendering.
- Dispatch now enqueues `CopyBufferSubData(SSBO → PBO[N%2])` + a `FenceSync` — both return immediately on the CPU.
- Readback calls `ClientWaitSync(timeout=0)` (non-blocking); if the fence is signalled, maps the PBO and converts pixels without waiting on the GPU; otherwise skips the frame.
- 1-frame readback latency — imperceptible for progressive rendering.

## Files changed

- `raytrace/gpu_types.odin` — adds `pbo[2]`, `pbo_fence[2]`, `pbo_size`, `pbo_sample_at_fill[2]`, `pbo_frame` to `GPUBackend`
- `raytrace/gpu_backend.odin` — init (allocate PBOs), dispatch (copy + fence after barrier), readback (async map path), destroy (cleanup)

## Test plan

- [ ] Build with `make debug`
- [ ] Run `./build/debug -gpu -s 50` — editor should remain responsive throughout the render, with no visible freeze per frame
- [ ] Render completes and output matches CPU path quality
- [ ] Run `./build/debug -gpu -s 1` — single sample renders and displays correctly
- [ ] CPU path (`./build/debug -s 50`) unaffected

## Notes

- The very first frame returns early (out[] unchanged → black for one tick), then fully async from frame 2 onward.
- All GL calls remain on the main thread — no context-sharing issues with Raylib.
- Resolves: #129
- Part of: #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)