### PR TITLE
Add GPU render mode controls: Continuous mode and Restart (#130)

### DIFF
--- a/editor/app.odin
+++ b/editor/app.odin
@@ -788,13 +788,20 @@ run_app :: proc(
             }
         }
 
-        // GPU path: dispatch one more sample per frame until all samples done.
+        // GPU path: dispatch one more sample per frame.
+        // In Continuous mode, automatically reset and restart when all samples are done.
+        // In SingleShot mode (default), stop dispatching once total_samples is reached.
         if app.r_session.use_gpu {
             gpu_rend := app.r_session.gpu_renderer
-            if gpu_rend != nil && !rt.gpu_renderer_done(gpu_rend) {
-                gpu_dispatch_scope := util.trace_scope_begin("Gpu.Dispatch", "render")
-                defer util.trace_scope_end(gpu_dispatch_scope)
-                rt.gpu_renderer_dispatch(gpu_rend)
+            if gpu_rend != nil {
+                if gpu_rend.mode == .Continuous && rt.gpu_renderer_done(gpu_rend) {
+                    rt.gpu_renderer_restart(gpu_rend)
+                }
+                if !rt.gpu_renderer_done(gpu_rend) {
+                    gpu_dispatch_scope := util.trace_scope_begin("Gpu.Dispatch", "render")
+                    defer util.trace_scope_end(gpu_dispatch_scope)
+                    rt.gpu_renderer_dispatch(gpu_rend)
+                }
             }
         }
 

--- a/editor/panel_stats.odin
+++ b/editor/panel_stats.odin
@@ -13,6 +13,23 @@ _stats_gpu_checkbox_rect :: proc(content: rl.Rectangle) -> rl.Rectangle {
 _stats_gpu_row_rect :: proc(content: rl.Rectangle) -> rl.Rectangle {
     return rl.Rectangle{ content.x + 10, content.y + 4, 120, 20 }
 }
+// Y position of the Continuous/Restart row:
+//   base(8) + Next-render-row(20) + Mode-row(20) = 48 below content.y
+_stats_gpu_controls_y :: proc(content: rl.Rectangle) -> i32 {
+    return i32(content.y) + 48
+}
+_stats_continuous_checkbox_rect :: proc(content: rl.Rectangle) -> rl.Rectangle {
+    y := f32(_stats_gpu_controls_y(content))
+    return rl.Rectangle{ content.x + 10, y + 2, 14, 14 }
+}
+_stats_continuous_row_rect :: proc(content: rl.Rectangle) -> rl.Rectangle {
+    y := f32(_stats_gpu_controls_y(content))
+    return rl.Rectangle{ content.x + 10, y, 100, 20 }
+}
+_stats_restart_btn_rect :: proc(content: rl.Rectangle) -> rl.Rectangle {
+    y := f32(_stats_gpu_controls_y(content))
+    return rl.Rectangle{ content.x + 115, y + 1, 54, 18 }
+}
 
 draw_stats_content :: proc(app: ^App, content: rl.Rectangle) {
     x := i32(content.x) + 10
@@ -44,6 +61,34 @@ draw_stats_content :: proc(app: ^App, content: rl.Rectangle) {
     mode := session.use_gpu ? cstring("GPU") : cstring("CPU")
     draw_ui_text(app, fmt.ctprintf("Mode:     %s", mode), x, y, fs, CONTENT_TEXT_COLOR)
     y += line_h
+
+    // GPU-only controls: Continuous toggle + Restart button.
+    if session.use_gpu && session.gpu_renderer != nil {
+        gpu_rend := session.gpu_renderer
+        is_continuous := gpu_rend.mode == .Continuous
+
+        // Continuous checkbox.
+        cont_box := _stats_continuous_checkbox_rect(content)
+        rl.DrawRectangleLinesEx(cont_box, 1, BORDER_COLOR)
+        if is_continuous {
+            rl.DrawRectangle(
+                i32(cont_box.x) + 2, i32(cont_box.y) + 2,
+                i32(cont_box.width) - 4, i32(cont_box.height) - 4,
+                ACCENT_COLOR,
+            )
+        }
+        draw_ui_text(app, " Continuous", i32(cont_box.x + cont_box.width + 2), y + 2, 12, CONTENT_TEXT_COLOR)
+
+        // Restart button.
+        restart_rect := _stats_restart_btn_rect(content)
+        mouse := rl.GetMousePosition()
+        btn_color := rl.CheckCollisionPointRec(mouse, restart_rect) ? rl.Color{70, 80, 110, 220} : rl.Color{45, 50, 70, 200}
+        rl.DrawRectangleRec(restart_rect, btn_color)
+        rl.DrawRectangleLinesEx(restart_rect, 1, BORDER_COLOR)
+        draw_ui_text(app, "Restart", i32(restart_rect.x) + 5, i32(restart_rect.y) + 2, 11, CONTENT_TEXT_COLOR)
+
+        y += line_h
+    }
 
     // Progress line: GPU shows sample count; CPU shows tile count.
     progress_frac := f32(0)
@@ -168,9 +213,32 @@ draw_stats_content :: proc(app: ^App, content: rl.Rectangle) {
 
 update_stats_content :: proc(app: ^App, rect: rl.Rectangle, mouse: rl.Vector2, lmb: bool, lmb_pressed: bool) {
     if !lmb_pressed { return }
-    row := _stats_gpu_row_rect(rect)
-    if rl.CheckCollisionPointRec(mouse, row) {
+
+    // "Next render: GPU/CPU" toggle.
+    if rl.CheckCollisionPointRec(mouse, _stats_gpu_row_rect(rect)) {
         app.prefer_gpu = !app.prefer_gpu
+        if g_app != nil { g_app.input_consumed = true }
+        return
+    }
+
+    // GPU-only controls: only active when a GPU render session is live.
+    session := app.r_session
+    if session == nil || !session.use_gpu || session.gpu_renderer == nil { return }
+    gpu_rend := session.gpu_renderer
+
+    // Continuous mode toggle.
+    if rl.CheckCollisionPointRec(mouse, _stats_continuous_row_rect(rect)) {
+        new_mode := rt.GpuRenderMode.Continuous if gpu_rend.mode == .SingleShot else rt.GpuRenderMode.SingleShot
+        rt.gpu_renderer_set_mode(gpu_rend, new_mode)
+        if g_app != nil { g_app.input_consumed = true }
+        return
+    }
+
+    // Restart button: zero accumulation and restart from sample 0.
+    if rl.CheckCollisionPointRec(mouse, _stats_restart_btn_rect(rect)) {
+        rt.gpu_renderer_restart(gpu_rend)
+        app.finished     = false
+        app.render_start = app.render_start // keep elapsed clock running
         if g_app != nil { g_app.input_consumed = true }
     }
 }

--- a/raytrace/gpu_backend.odin
+++ b/raytrace/gpu_backend.odin
@@ -545,6 +545,38 @@ gpu_backend_readback :: proc(b: ^GPUBackend, out: [][4]u8) {
     gl.BindBuffer(gl.COPY_READ_BUFFER, 0)
 }
 
+// ── gpu_backend_reset ────────────────────────────────────────────────────────
+
+// gpu_backend_reset zeroes the output accumulation SSBO and resets all sample
+// and timing counters so the next dispatch begins a fresh progressive render.
+// Scene data (spheres, BVH, quads) is untouched — only the pixel accumulation
+// is cleared.  Call to restart without rebuilding the full GPU backend.
+gpu_backend_reset :: proc(b: ^GPUBackend) {
+    if b == nil { return }
+    // Zero the output accumulation SSBO.
+    pixel_count := b.width * b.height
+    zeroes      := make([][4]f32, pixel_count)
+    defer delete(zeroes)
+    gl.BindBuffer(gl.SHADER_STORAGE_BUFFER, b.ssbo_output)
+    gl.BufferSubData(gl.SHADER_STORAGE_BUFFER, 0, pixel_count * size_of([4]f32), raw_data(zeroes))
+    gl.BindBuffer(gl.SHADER_STORAGE_BUFFER, 0)
+    // Reset sample and timing counters.
+    b.current_sample      = 0
+    b.dispatch_total_ns   = 0
+    b.readback_total_ns   = 0
+    b.gpu_dispatch_total_ns = 0
+    // Reset timer query so the next dispatch can start a new Begin/End pair.
+    b.timer_query_pending = false
+    // Release any pending PBO fences — their data is stale after the SSBO reset.
+    for i in 0..<2 {
+        if b.pbo_fence[i] != nil {
+            gl.DeleteSync(auto_cast b.pbo_fence[i])
+            b.pbo_fence[i] = nil
+        }
+    }
+    b.pbo_frame = 0
+}
+
 // ── gpu_backend_destroy ──────────────────────────────────────────────────────
 
 // gpu_backend_destroy deletes all GL objects associated with the backend and
@@ -596,6 +628,7 @@ _ogl_init :: proc(cam: ^Camera, world: []Object, spheres: []GPUSphere, quads: []
 @(private) _ogl_dispatch    :: proc(s: rawptr) { gpu_backend_dispatch((^GPUBackend)(s)) }
 @(private) _ogl_readback    :: proc(s: rawptr, out: [][4]u8) { gpu_backend_readback((^GPUBackend)(s), out) }
 @(private) _ogl_destroy     :: proc(s: rawptr) { gpu_backend_destroy((^GPUBackend)(s)) }
+@(private) _ogl_reset       :: proc(s: rawptr) { gpu_backend_reset((^GPUBackend)(s)) }
 @(private) _ogl_get_samples :: proc(s: rawptr) -> (int, int) {
     b := (^GPUBackend)(s)
     return b.current_sample, b.total_samples
@@ -617,4 +650,5 @@ OPENGL_RENDERER_API :: GpuRendererApi{
     destroy     = _ogl_destroy,
     get_samples = _ogl_get_samples,
     get_timings = _ogl_get_timings,
+    reset       = _ogl_reset,
 }

--- a/raytrace/gpu_renderer.odin
+++ b/raytrace/gpu_renderer.odin
@@ -1,10 +1,15 @@
 package raytrace
 
+// GpuRenderMode controls whether the GPU renderer stops after reaching
+// total_samples (SingleShot) or automatically resets and keeps accumulating
+// (Continuous).  Default is SingleShot, matching the CPU path behaviour.
+GpuRenderMode :: enum { SingleShot, Continuous }
+
 // GpuRendererApi is a vtable for a GPU rendering backend.
 //
 // To add a new backend (e.g. Metal, Vulkan, DX12):
 //   1. Define a backend-specific state struct.
-//   2. Implement the five procs below for that struct.
+//   2. Implement the procs below for that struct.
 //   3. Declare a package-level constant MY_RENDERER_API :: GpuRendererApi{...}.
 //   4. Add a `when ODIN_OS == .Whatever` branch in create_gpu_renderer() to try it.
 GpuRendererApi :: struct {
@@ -14,11 +19,13 @@ GpuRendererApi :: struct {
     destroy:     proc "odin" (state: rawptr),
     get_samples: proc "odin" (state: rawptr) -> (int, int),
     get_timings: proc "odin" (state: rawptr) -> (i64, i64),  // dispatch_ns, readback_ns
+    reset:       proc "odin" (state: rawptr),                 // zero accumulation, restart from sample 0
 }
 
 GpuRenderer :: struct {
     api:   GpuRendererApi,
     state: rawptr,
+    mode:  GpuRenderMode, // SingleShot = stop after total_samples; Continuous = loop forever
 }
 
 // Helper procs — callers use these, never the vtable directly.
@@ -35,6 +42,13 @@ gpu_renderer_get_timings :: proc(r: ^GpuRenderer) -> (disp_ns: i64, read_ns: i64
 gpu_renderer_done :: proc(r: ^GpuRenderer) -> bool {
     cur, tot := r.api.get_samples(r.state)
     return tot > 0 && cur >= tot
+}
+// gpu_renderer_set_mode changes the loop behaviour for the next dispatch cycle.
+gpu_renderer_set_mode :: proc(r: ^GpuRenderer, mode: GpuRenderMode) { r.mode = mode }
+// gpu_renderer_restart zeros the accumulation buffer and resets the sample counter
+// so the next dispatch starts a fresh render without rebuilding the scene or shaders.
+gpu_renderer_restart :: proc(r: ^GpuRenderer) {
+    if r.api.reset != nil { r.api.reset(r.state) }
 }
 
 // create_gpu_renderer is the platform-aware factory.


### PR DESCRIPTION
## Summary

- Adds `GpuRenderMode :: enum { SingleShot, Continuous }` — Single-shot stops after `total_samples` (existing behaviour); Continuous automatically resets and restarts accumulation indefinitely.
- Adds a soft-reset path (`gpu_backend_reset`) that zeroes the output SSBO and clears all counters without rebuilding the scene, shaders, or BVH.
- Stats panel gains a **Continuous** toggle checkbox and a **Restart** button, both visible only during a live GPU render session.

## Files changed

- `raytrace/gpu_renderer.odin` — `GpuRenderMode` enum, `reset` vtable slot, `mode` field on `GpuRenderer`, `gpu_renderer_set_mode` / `gpu_renderer_restart` helpers
- `raytrace/gpu_backend.odin` — `gpu_backend_reset` proc + `_ogl_reset` vtable wrapper wired into `OPENGL_RENDERER_API`
- `editor/app.odin` — dispatch loop: if Continuous and done, restart before dispatching; progress never hits 1.0 so `finish_render` is never called automatically
- `editor/panel_stats.odin` — Continuous checkbox + Restart button with hover highlight; `update_stats_content` handles clicks for both

## Test plan

- [ ] `make debug` — clean build
- [ ] `./build/debug -gpu -s 20` — single-shot: render completes and stops at 20 samples as before
- [ ] Enable **Continuous** in Stats panel — render loops indefinitely, accumulating more samples each pass; image quality visibly improves over time
- [ ] Click **Restart** — SSBO zeroes, sample counter resets, image restarts from scratch without reloading the scene
- [ ] Click **Restart** in Continuous mode — loops continue cleanly after reset
- [ ] CPU path (`./build/debug`) — Stats panel unchanged, no regression

## Notes

- `gpu_backend_reset` also clears any pending PBO fences (from #132) and resets the timer query pending flag (from #133) so the next dispatch starts both subsystems from a clean state.
- Closes #130 | Part of #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)