### PR TITLE
Add default ImGui docking layout for editor (#152)

### DIFF
--- a/editor/app.odin
+++ b/editor/app.odin
@@ -173,6 +173,7 @@ app_restart_render_with_scene :: proc(app: ^App, scene_objects: []core.SceneSphe
 
 App :: struct {
     e_panel_vis:   ImguiPanelVis,
+    e_reset_layout: bool,
 
     render_tex:    rl.Texture2D,
     pixel_staging: []rl.Color,
@@ -505,6 +506,8 @@ run_app :: proc(
         content_browser = true,
         outliner        = true,
     }
+
+    app.e_reset_layout = !os.exists("imgui.ini")
 
     g_app = &app
     rl.SetTraceLogCallback(cast(rl.TraceLogCallback)app_trace_log)

--- a/editor/imgui_panels_stub.odin
+++ b/editor/imgui_panels_stub.odin
@@ -64,6 +64,10 @@ imgui_draw_main_menu_bar :: proc(app: ^App) {
         if imgui.MenuItem("ImGui Metrics",   nil, app.e_panel_vis.imgui_metrics)    {
             app.e_panel_vis.imgui_metrics = !app.e_panel_vis.imgui_metrics
         }
+        imgui.Separator()
+        if imgui.MenuItem("Reset Layout") {
+            app.e_reset_layout = true
+        }
         imgui.EndMenu()
     }
 
@@ -833,7 +837,11 @@ imgui_draw_outliner_panel :: proc(app: ^App) {
 // imgui_draw_all_panels draws the DockSpace, menu bar, and all panel windows.
 // Call this between imgui_rl_new_frame() and imgui_rl_render().
 imgui_draw_all_panels :: proc(app: ^App) {
-    imgui.DockSpaceOverViewport({}, nil, {.PassthruCentralNode})
+    dockspace_id := imgui.DockSpaceOverViewport({}, nil, {.PassthruCentralNode})
+    if app.e_reset_layout {
+        imgui_build_default_layout(dockspace_id)
+        app.e_reset_layout = false
+    }
     imgui_draw_main_menu_bar(app)
 
     // While a floating panel is being dragged by its title bar, make all windows
@@ -866,4 +874,53 @@ imgui_draw_all_panels :: proc(app: ^App) {
     if app.e_panel_vis.imgui_metrics {
         imgui.ShowMetricsWindow(&app.e_panel_vis.imgui_metrics)
     }
+}
+
+// imgui_build_default_layout creates a UE5/Godot-inspired docking layout using
+// the DockBuilder API.  Called on first launch (no imgui.ini) or View → Reset Layout.
+imgui_build_default_layout :: proc(dockspace_id: imgui.ID) {
+    imgui.DockBuilderRemoveNodeChildNodes(dockspace_id)
+
+    vp := imgui.GetMainViewport()
+    imgui.DockBuilderSetNodeSize(dockspace_id, vp.Size)
+    imgui.DockBuilderSetNodePos(dockspace_id, vp.Pos)
+
+    // Split root: left sidebar (18%) | center+right
+    left_id, center_right_id: imgui.ID
+    imgui.DockBuilderSplitNode(dockspace_id, .Left, 0.18, &left_id, &center_right_id)
+
+    // Split center+right: center | right sidebar (27% of remainder ≈ 22% total)
+    right_id, center_id: imgui.ID
+    imgui.DockBuilderSplitNode(center_right_id, .Right, 0.27, &right_id, &center_id)
+
+    // Split left: top (outliner) | bottom 40% (content browser)
+    left_bottom_id, left_top_id: imgui.ID
+    imgui.DockBuilderSplitNode(left_id, .Down, 0.40, &left_bottom_id, &left_top_id)
+
+    // Split center: top (viewport) | bottom 30% (console/stats/etc)
+    center_bottom_id, center_top_id: imgui.ID
+    imgui.DockBuilderSplitNode(center_id, .Down, 0.30, &center_bottom_id, &center_top_id)
+
+    // Split right: top (details/camera) | bottom 35% (camera preview/texture view)
+    right_bottom_id, right_top_id: imgui.ID
+    imgui.DockBuilderSplitNode(right_id, .Down, 0.35, &right_bottom_id, &right_top_id)
+
+    // Dock windows into nodes
+    imgui.DockBuilderDockWindow("World Outliner",  left_top_id)
+    imgui.DockBuilderDockWindow("Content Browser", left_bottom_id)
+
+    imgui.DockBuilderDockWindow("Viewport",        center_top_id)
+
+    imgui.DockBuilderDockWindow("Console",         center_bottom_id)
+    imgui.DockBuilderDockWindow("Stats",           center_bottom_id)
+    imgui.DockBuilderDockWindow("System Info",     center_bottom_id)
+    imgui.DockBuilderDockWindow("Render Preview",  center_bottom_id)
+
+    imgui.DockBuilderDockWindow("Details",         right_top_id)
+    imgui.DockBuilderDockWindow("Camera",          right_top_id)
+
+    imgui.DockBuilderDockWindow("Camera Preview",  right_bottom_id)
+    imgui.DockBuilderDockWindow("Texture View",    right_bottom_id)
+
+    imgui.DockBuilderFinish(dockspace_id)
 }


### PR DESCRIPTION
## Summary
- Adds a UE5/Godot-inspired default docking layout using the ImGui DockBuilder API, applied automatically on first launch (no `imgui.ini`) or manually via **View → Reset Layout**
- Arranges all 11 panels into a 3-column layout: left sidebar (World Outliner, Content Browser), center (Viewport, Console/Stats/SysInfo/Render Preview tabbed), right sidebar (Details/Camera tabbed, Camera Preview/Texture View tabbed)
- Subsequent launches restore the user's custom layout from `imgui.ini` — DockBuilder is not called unless explicitly reset

## Test plan
- [ ] `rm -f imgui.ini && make debug && ./build/debug` — verify organized default layout appears
- [ ] Drag panels around, close app, relaunch — verify custom layout is preserved
- [ ] View → Reset Layout — verify panels snap back to default arrangement
- [ ] Resize window — verify panels reflow proportionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)