### PR TITLE
Vulkan resource management & synchronization (#72)

### DIFF
--- a/tools/vk_smoke/main.odin
+++ b/tools/vk_smoke/main.odin
@@ -273,38 +273,25 @@ run_compute_test :: proc(ctx: ^vk_ctx.VulkanContext) -> bool {
 	vk_ctx.write_raytrace_descriptors(ctx.device, pipeline.descriptor_set, buffers)
 	fmt.println("  compute: buffers + descriptors OK")
 
-	// 4. Record and submit a compute dispatch.
-	cmd_alloc := vk.CommandBufferAllocateInfo {
-		sType              = .COMMAND_BUFFER_ALLOCATE_INFO,
-		commandPool        = ctx.command_pool,
-		level              = .PRIMARY,
-		commandBufferCount = 1,
+	// 4. Record and submit a compute dispatch using sync utilities.
+	cmd, cmd_ok := vk_ctx.begin_one_shot(ctx.device, ctx.compute_command_pool)
+	if !cmd_ok { return false }
+
+	vk_ctx.dispatch_compute_synced(cmd, vk_ctx.DispatchSyncConfig{
+		ctx          = ctx,
+		pipeline     = &pipeline,
+		groups_x     = u32(math.ceil(f32(W) / 8.0)),
+		groups_y     = u32(math.ceil(f32(H) / 8.0)),
+		groups_z     = 1,
+		output_buffer = output.buffer,
+		output_size   = OUT_SIZE,
+		readback_host = true,
+	})
+
+	if !vk_ctx.end_one_shot_and_submit(ctx.device, ctx.compute_command_pool, ctx.compute_queue, cmd) {
+		return false
 	}
-	cmd: vk.CommandBuffer
-	if vk.AllocateCommandBuffers(ctx.device, &cmd_alloc, &cmd) != .SUCCESS { return false }
-	defer vk.FreeCommandBuffers(ctx.device, ctx.command_pool, 1, &cmd)
-
-	begin := vk.CommandBufferBeginInfo {
-		sType = .COMMAND_BUFFER_BEGIN_INFO,
-		flags = {.ONE_TIME_SUBMIT},
-	}
-	if vk.BeginCommandBuffer(cmd, &begin) != .SUCCESS { return false }
-
-	vk.CmdBindPipeline(cmd, .COMPUTE, pipeline.pipeline)
-	vk.CmdBindDescriptorSets(cmd, .COMPUTE, pipeline.pipeline_layout, 0, 1, &pipeline.descriptor_set, 0, nil)
-	vk.CmdDispatch(cmd, u32(math.ceil(f32(W) / 8.0)), u32(math.ceil(f32(H) / 8.0)), 1)
-
-	if vk.EndCommandBuffer(cmd) != .SUCCESS { return false }
-
-	if vk.ResetFences(ctx.device, 1, &ctx.fence) != .SUCCESS { return false }
-	submit := vk.SubmitInfo {
-		sType              = .SUBMIT_INFO,
-		commandBufferCount = 1,
-		pCommandBuffers    = &cmd,
-	}
-	if vk.QueueSubmit(ctx.compute_queue, 1, &submit, ctx.fence) != .SUCCESS { return false }
-	vk.WaitForFences(ctx.device, 1, &ctx.fence, true, ~u64(0))
-	fmt.println("  compute: dispatch OK")
+	fmt.println("  compute: dispatch OK (with sync barriers)")
 
 	// 5. Read back and verify.
 	pixels := (^[PIXEL_COUNT][4]f32)(output.mapped)

--- a/vk_ctx/vulkan_context.odin
+++ b/vk_ctx/vulkan_context.odin
@@ -48,6 +48,7 @@ VulkanContext :: struct {
 	present_queue:           vk.Queue,
 	compute_queue:           vk.Queue,
 	command_pool:            vk.CommandPool,
+	compute_command_pool:    vk.CommandPool, // separate pool when compute family != graphics family
 	surface:                 vk.SurfaceKHR,
 	fence:                   vk.Fence,
 	semaphore_image_available: vk.Semaphore,
@@ -515,6 +516,11 @@ vulkan_context_destroy :: proc(ctx: ^VulkanContext) {
 		vk.DestroyFence(ctx.device, ctx.fence, nil)
 		ctx.fence = {}
 	}
+	// Destroy compute command pool only if it is a distinct pool (not shared with graphics).
+	if ctx.compute_command_pool != vk.CommandPool(0) && ctx.compute_command_pool != ctx.command_pool {
+		vk.DestroyCommandPool(ctx.device, ctx.compute_command_pool, nil)
+	}
+	ctx.compute_command_pool = {}
 	if ctx.command_pool != vk.CommandPool(0) {
 		vk.DestroyCommandPool(ctx.device, ctx.command_pool, nil)
 		ctx.command_pool = {}

--- a/vk_ctx/vulkan_context_headless.odin
+++ b/vk_ctx/vulkan_context_headless.odin
@@ -81,6 +81,11 @@ vulkan_context_init_headless :: proc(use_null_platform := true, use_glfw_loader 
 		return ctx, false
 	}
 
+	if !create_compute_command_pool(&ctx) {
+		vulkan_context_destroy(&ctx)
+		return ctx, false
+	}
+
 	return ctx, true
 }
 

--- a/vk_ctx/vulkan_context_window.odin
+++ b/vk_ctx/vulkan_context_window.odin
@@ -110,5 +110,10 @@ vulkan_context_init_window :: proc(
 		return ctx, false
 	}
 
+	if !create_compute_command_pool(&ctx) {
+		vulkan_context_destroy(&ctx)
+		return ctx, false
+	}
+
 	return ctx, true
 }

--- a/vk_ctx/vulkan_sync.odin
+++ b/vk_ctx/vulkan_sync.odin
@@ -1,0 +1,341 @@
+package vk_ctx
+
+import "core:fmt"
+
+import vk "vendor:vulkan"
+
+// ─── Compute command pool ────────────────────────────────────────────────────
+//
+// When the compute queue family differs from the graphics family, a separate
+// command pool is required.  create_compute_command_pool creates one; the pool
+// handle is stored in VulkanContext.compute_command_pool and destroyed by
+// vulkan_context_destroy.
+
+create_compute_command_pool :: proc(ctx: ^VulkanContext) -> bool {
+	// If compute uses the same family as graphics, reuse the existing pool.
+	if ctx.compute_queue_family == ctx.graphics_queue_family {
+		ctx.compute_command_pool = ctx.command_pool
+		return true
+	}
+	pool_info := vk.CommandPoolCreateInfo {
+		sType            = .COMMAND_POOL_CREATE_INFO,
+		flags            = {.RESET_COMMAND_BUFFER},
+		queueFamilyIndex = ctx.compute_queue_family,
+	}
+	if vk.CreateCommandPool(ctx.device, &pool_info, nil, &ctx.compute_command_pool) != .SUCCESS {
+		fmt.eprintln("vk_ctx: compute command pool creation failed")
+		return false
+	}
+	return true
+}
+
+// ─── One-shot command helpers ────────────────────────────────────────────────
+
+// begin_one_shot allocates and begins a primary command buffer for single-use
+// recording.  Use with end_one_shot_and_submit.
+begin_one_shot :: proc(
+	device: vk.Device,
+	pool: vk.CommandPool,
+) -> (cmd: vk.CommandBuffer, ok: bool) {
+	alloc_info := vk.CommandBufferAllocateInfo {
+		sType              = .COMMAND_BUFFER_ALLOCATE_INFO,
+		commandPool        = pool,
+		level              = .PRIMARY,
+		commandBufferCount = 1,
+	}
+	if vk.AllocateCommandBuffers(device, &alloc_info, &cmd) != .SUCCESS {
+		return {}, false
+	}
+	begin := vk.CommandBufferBeginInfo {
+		sType = .COMMAND_BUFFER_BEGIN_INFO,
+		flags = {.ONE_TIME_SUBMIT},
+	}
+	if vk.BeginCommandBuffer(cmd, &begin) != .SUCCESS {
+		vk.FreeCommandBuffers(device, pool, 1, &cmd)
+		return {}, false
+	}
+	return cmd, true
+}
+
+// end_one_shot_and_submit ends the command buffer, submits it to the given
+// queue, waits for completion via a temporary fence, and frees the buffer.
+end_one_shot_and_submit :: proc(
+	device: vk.Device,
+	pool: vk.CommandPool,
+	queue: vk.Queue,
+	cmd: vk.CommandBuffer,
+) -> bool {
+	cmd_mut := cmd
+	if vk.EndCommandBuffer(cmd) != .SUCCESS {
+		vk.FreeCommandBuffers(device, pool, 1, &cmd_mut)
+		return false
+	}
+	fence_ci := vk.FenceCreateInfo { sType = .FENCE_CREATE_INFO }
+	fence: vk.Fence
+	if vk.CreateFence(device, &fence_ci, nil, &fence) != .SUCCESS {
+		vk.FreeCommandBuffers(device, pool, 1, &cmd_mut)
+		return false
+	}
+	submit := vk.SubmitInfo {
+		sType              = .SUBMIT_INFO,
+		commandBufferCount = 1,
+		pCommandBuffers    = &cmd_mut,
+	}
+	res := vk.QueueSubmit(queue, 1, &submit, fence)
+	if res != .SUCCESS {
+		vk.DestroyFence(device, fence, nil)
+		vk.FreeCommandBuffers(device, pool, 1, &cmd_mut)
+		return false
+	}
+	vk.WaitForFences(device, 1, &fence, true, ~u64(0))
+	vk.DestroyFence(device, fence, nil)
+	vk.FreeCommandBuffers(device, pool, 1, &cmd_mut)
+	return true
+}
+
+// ─── Buffer memory barriers ─────────────────────────────────────────────────
+
+// barrier_compute_write_to_host_read inserts a pipeline barrier that makes
+// compute-shader SSBO writes visible to host reads (e.g. vkMapMemory / CPU
+// readback).  Use after the last dispatch before readback.
+barrier_compute_write_to_host_read :: proc(cmd: vk.CommandBuffer, buffer: vk.Buffer, size: vk.DeviceSize) {
+	barrier := vk.BufferMemoryBarrier {
+		sType               = .BUFFER_MEMORY_BARRIER,
+		srcAccessMask       = {.SHADER_WRITE},
+		dstAccessMask       = {.HOST_READ},
+		srcQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		dstQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		buffer              = buffer,
+		offset              = 0,
+		size                = size,
+	}
+	vk.CmdPipelineBarrier(
+		cmd,
+		{.COMPUTE_SHADER},  // src stage
+		{.HOST},             // dst stage
+		{},                  // dependency flags
+		0, nil,              // memory barriers
+		1, &barrier,         // buffer barriers
+		0, nil,              // image barriers
+	)
+}
+
+// barrier_compute_write_to_compute_read inserts a barrier between two compute
+// dispatches on the same queue so that SSBO writes from the first dispatch are
+// visible to shader reads in the next.  Essential for multi-sample accumulation.
+barrier_compute_write_to_compute_read :: proc(cmd: vk.CommandBuffer, buffer: vk.Buffer, size: vk.DeviceSize) {
+	barrier := vk.BufferMemoryBarrier {
+		sType               = .BUFFER_MEMORY_BARRIER,
+		srcAccessMask       = {.SHADER_WRITE},
+		dstAccessMask       = {.SHADER_READ, .SHADER_WRITE},
+		srcQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		dstQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		buffer              = buffer,
+		offset              = 0,
+		size                = size,
+	}
+	vk.CmdPipelineBarrier(
+		cmd,
+		{.COMPUTE_SHADER},  // src stage
+		{.COMPUTE_SHADER},  // dst stage
+		{},
+		0, nil,
+		1, &barrier,
+		0, nil,
+	)
+}
+
+// barrier_compute_write_to_transfer_read inserts a barrier so that compute-shader
+// SSBO writes are visible to a subsequent transfer (vkCmdCopyBuffer) for readback
+// to a staging buffer or presentation path.
+barrier_compute_write_to_transfer_read :: proc(cmd: vk.CommandBuffer, buffer: vk.Buffer, size: vk.DeviceSize) {
+	barrier := vk.BufferMemoryBarrier {
+		sType               = .BUFFER_MEMORY_BARRIER,
+		srcAccessMask       = {.SHADER_WRITE},
+		dstAccessMask       = {.TRANSFER_READ},
+		srcQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		dstQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		buffer              = buffer,
+		offset              = 0,
+		size                = size,
+	}
+	vk.CmdPipelineBarrier(
+		cmd,
+		{.COMPUTE_SHADER},
+		{.TRANSFER},
+		{},
+		0, nil,
+		1, &barrier,
+		0, nil,
+	)
+}
+
+// barrier_transfer_write_to_host_read inserts a barrier so that a transfer write
+// (vkCmdCopyBuffer into a staging buffer) is visible to host reads.
+barrier_transfer_write_to_host_read :: proc(cmd: vk.CommandBuffer, buffer: vk.Buffer, size: vk.DeviceSize) {
+	barrier := vk.BufferMemoryBarrier {
+		sType               = .BUFFER_MEMORY_BARRIER,
+		srcAccessMask       = {.TRANSFER_WRITE},
+		dstAccessMask       = {.HOST_READ},
+		srcQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		dstQueueFamilyIndex = vk.QUEUE_FAMILY_IGNORED,
+		buffer              = buffer,
+		offset              = 0,
+		size                = size,
+	}
+	vk.CmdPipelineBarrier(
+		cmd,
+		{.TRANSFER},
+		{.HOST},
+		{},
+		0, nil,
+		1, &barrier,
+		0, nil,
+	)
+}
+
+// ─── Queue family ownership transfers ────────────────────────────────────────
+//
+// When the compute and graphics queue families differ, exclusive-mode buffers
+// require an ownership transfer: a release barrier on the source queue followed
+// by an acquire barrier on the destination queue.
+
+// barrier_queue_release records a release barrier that transfers ownership of a
+// buffer from src_family to dst_family.  Record into a command buffer submitted
+// on the source queue.
+barrier_queue_release :: proc(
+	cmd: vk.CommandBuffer,
+	buffer: vk.Buffer,
+	size: vk.DeviceSize,
+	src_access: vk.AccessFlags,
+	src_stage: vk.PipelineStageFlags,
+	src_family: u32,
+	dst_family: u32,
+) {
+	if src_family == dst_family { return }
+	barrier := vk.BufferMemoryBarrier {
+		sType               = .BUFFER_MEMORY_BARRIER,
+		srcAccessMask       = src_access,
+		dstAccessMask       = {},
+		srcQueueFamilyIndex = src_family,
+		dstQueueFamilyIndex = dst_family,
+		buffer              = buffer,
+		offset              = 0,
+		size                = size,
+	}
+	vk.CmdPipelineBarrier(
+		cmd,
+		src_stage,
+		{.BOTTOM_OF_PIPE},
+		{},
+		0, nil,
+		1, &barrier,
+		0, nil,
+	)
+}
+
+// barrier_queue_acquire records an acquire barrier that completes ownership
+// transfer of a buffer from src_family to dst_family.  Record into a command
+// buffer submitted on the destination queue.
+barrier_queue_acquire :: proc(
+	cmd: vk.CommandBuffer,
+	buffer: vk.Buffer,
+	size: vk.DeviceSize,
+	dst_access: vk.AccessFlags,
+	dst_stage: vk.PipelineStageFlags,
+	src_family: u32,
+	dst_family: u32,
+) {
+	if src_family == dst_family { return }
+	barrier := vk.BufferMemoryBarrier {
+		sType               = .BUFFER_MEMORY_BARRIER,
+		srcAccessMask       = {},
+		dstAccessMask       = dst_access,
+		srcQueueFamilyIndex = src_family,
+		dstQueueFamilyIndex = dst_family,
+		buffer              = buffer,
+		offset              = 0,
+		size                = size,
+	}
+	vk.CmdPipelineBarrier(
+		cmd,
+		{.TOP_OF_PIPE},
+		dst_stage,
+		{},
+		0, nil,
+		1, &barrier,
+		0, nil,
+	)
+}
+
+// ─── Semaphore helpers ───────────────────────────────────────────────────────
+
+// create_semaphore creates a binary semaphore for inter-queue synchronization.
+create_semaphore :: proc(device: vk.Device) -> (vk.Semaphore, bool) {
+	ci := vk.SemaphoreCreateInfo { sType = .SEMAPHORE_CREATE_INFO }
+	sem: vk.Semaphore
+	if vk.CreateSemaphore(device, &ci, nil, &sem) != .SUCCESS {
+		fmt.eprintln("vk_ctx: vkCreateSemaphore failed")
+		return {}, false
+	}
+	return sem, true
+}
+
+// create_fence creates a fence, optionally pre-signaled.
+create_fence :: proc(device: vk.Device, signaled: bool = false) -> (vk.Fence, bool) {
+	flags: vk.FenceCreateFlags
+	if signaled { flags = {.SIGNALED} }
+	ci := vk.FenceCreateInfo {
+		sType = .FENCE_CREATE_INFO,
+		flags = flags,
+	}
+	fence: vk.Fence
+	if vk.CreateFence(device, &ci, nil, &fence) != .SUCCESS {
+		fmt.eprintln("vk_ctx: vkCreateFence failed")
+		return {}, false
+	}
+	return fence, true
+}
+
+// ─── Compute dispatch with synchronization ──────────────────────────────────
+
+// DispatchSyncConfig describes a compute dispatch with all required barriers.
+DispatchSyncConfig :: struct {
+	ctx:             ^VulkanContext,
+	pipeline:        ^VulkanComputePipeline,
+	groups_x:        u32,
+	groups_y:        u32,
+	groups_z:        u32,
+	// Buffer that is written by the compute shader (e.g. output accumulation).
+	output_buffer:   vk.Buffer,
+	output_size:     vk.DeviceSize,
+	// If true, insert a compute→compute barrier after dispatch for multi-sample
+	// accumulation (next dispatch reads the same buffer).
+	accumulate:      bool,
+	// If true, insert a compute→host barrier after dispatch for CPU readback.
+	readback_host:   bool,
+	// If true, insert a compute→transfer barrier for staging-buffer copy readback.
+	readback_staged: bool,
+}
+
+// dispatch_compute_synced records a compute dispatch with appropriate post-dispatch
+// barriers into the given command buffer.  Does NOT submit — the caller controls
+// batching and submission.
+dispatch_compute_synced :: proc(cmd: vk.CommandBuffer, cfg: DispatchSyncConfig) {
+	vk.CmdBindPipeline(cmd, .COMPUTE, cfg.pipeline.pipeline)
+	vk.CmdBindDescriptorSets(
+		cmd, .COMPUTE, cfg.pipeline.pipeline_layout,
+		0, 1, &cfg.pipeline.descriptor_set, 0, nil,
+	)
+	vk.CmdDispatch(cmd, cfg.groups_x, cfg.groups_y, cfg.groups_z)
+
+	if cfg.accumulate {
+		barrier_compute_write_to_compute_read(cmd, cfg.output_buffer, cfg.output_size)
+	}
+	if cfg.readback_host {
+		barrier_compute_write_to_host_read(cmd, cfg.output_buffer, cfg.output_size)
+	}
+	if cfg.readback_staged {
+		barrier_compute_write_to_transfer_read(cmd, cfg.output_buffer, cfg.output_size)
+	}
+}


### PR DESCRIPTION
## Summary

- **New `vk_ctx/vulkan_sync.odin`**: Synchronization utilities for the Vulkan compute pipeline
  - Buffer memory barriers: compute→host, compute→compute (accumulation), compute→transfer, transfer→host
  - Queue family ownership transfers (release/acquire) for cross-family buffer handoff
  - One-shot command helpers (`begin_one_shot`, `end_one_shot_and_submit`)
  - `create_semaphore` / `create_fence` convenience factories
  - `dispatch_compute_synced` — configurable dispatch with post-dispatch barrier selection
- **Compute command pool**: Added `compute_command_pool` to `VulkanContext`; separate pool when compute queue family differs from graphics, shared handle otherwise
- **Init paths**: Wired `create_compute_command_pool` into headless and window context init
- **Cleanup**: Compute command pool destroyed in `vulkan_context_destroy` (only when distinct from graphics pool)
- **vk_smoke**: Compute test updated to use `begin_one_shot` + `dispatch_compute_synced` + `end_one_shot_and_submit`

Closes #72

## Test plan

- [x] `make vk-smoke && ./build/vk_smoke --headless --compute` — dispatch + readback verified with barriers
- [ ] `./build/vk_smoke --headless --clear` — clear-color submit still works
- [ ] `./build/vk_smoke --window --frames=60` — triangle present unaffected
- [ ] `make debug` — main editor builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)